### PR TITLE
Remove #[allow(dead_code)]

### DIFF
--- a/src/bitboard.rs
+++ b/src/bitboard.rs
@@ -1,7 +1,6 @@
 use square::*;
 use std::ops::{BitAnd, BitOr, BitXor, BitAndAssign, BitOrAssign, BitXorAssign, Mul, Not};
 use std::fmt;
-use std::sync::{Once, ONCE_INIT};
 use rank::Rank;
 use file::File;
 
@@ -10,9 +9,6 @@ use file::File;
 /// using the implemented operators to work with this object.
 #[derive(PartialEq, PartialOrd, Clone, Copy, Debug)]
 pub struct BitBoard(pub u64);
-
-#[allow(dead_code)]
-static SETUP: Once = ONCE_INIT;
 
 /// An empty bitboard
 pub const EMPTY: BitBoard = BitBoard(0);
@@ -94,31 +90,26 @@ impl fmt::Display for BitBoard {
 
 impl BitBoard {
     /// Construct a new bitboard from a u64
-    #[allow(dead_code)]
     pub fn new(b: u64) -> BitBoard {
         BitBoard(b)
     }
 
     /// Construct a new `BitBoard` with a particular `Square` set
-    #[allow(dead_code)]
     pub fn set(rank: Rank, file: File) -> BitBoard {
         BitBoard::from_square(Square::make_square(rank, file))
     }
 
     /// Construct a new `BitBoard` with a particular `Square` set
-    #[allow(dead_code)]
     pub fn from_square(sq: Square) -> BitBoard {
         BitBoard(1u64 << sq.to_int())
     }
 
     /// Convert an `Option<Square>` to an `Option<BitBoard>`
-    #[allow(dead_code)]
     pub fn from_maybe_square(sq: Option<Square>) -> Option<BitBoard> {
         sq.map(|s| BitBoard::from_square(s))
     }
 
     /// Convert a `BitBoard` to a `Square`.  This grabs the least-significant `Square`
-    #[allow(dead_code)]
     pub fn to_square(&self) -> Square {
         unsafe {
             Square::new(self.0.trailing_zeros() as u8)
@@ -126,19 +117,16 @@ impl BitBoard {
     }
 
     /// Count the number of `Squares` set in this `BitBoard`
-    #[allow(dead_code)]
     pub fn popcnt(&self) -> u32 {
         self.0.count_ones()
     }
 
     /// Reverse this `BitBoard`.  Look at it from the opponents perspective.
-    #[allow(dead_code)]
     pub fn reverse_colors(&self) -> BitBoard {
         BitBoard(self.0.swap_bytes())
     }
 
     /// Convert this `BitBoard` to a `usize` (for table lookups)
-    #[allow(dead_code)]
     pub fn to_size(&self, rightshift: u8) -> usize {
         (self.0 >> rightshift) as usize
     }
@@ -148,7 +136,6 @@ impl BitBoard {
 impl Iterator for BitBoard {
     type Item = Square;
 
-    #[allow(dead_code)]
     fn next(&mut self) -> Option<Square> {
         if self.0 == 0 {
             None

--- a/src/build.rs
+++ b/src/build.rs
@@ -1,6 +1,9 @@
 // This file generates 3 giant files, magic_gen.rs and zobrist_gen.rs
 // The purpose of this file is to create lookup tables that can be used during move generation.
 // This file has gotten pretty long and complicated, but hopefully the comments should allow
+
+#![allow(dead_code)]
+
 // it to be easily followed.
 extern crate rand;
 

--- a/src/castle_rights.rs
+++ b/src/castle_rights.rs
@@ -4,7 +4,6 @@ use square::Square;
 use file::File;
 /// What castle rights does a particular player have?
 #[derive(Copy, Clone, PartialEq, PartialOrd)]
-#[allow(dead_code)]
 pub enum CastleRights {
     NoRights,
     KingSide,
@@ -13,35 +12,29 @@ pub enum CastleRights {
 }
 
 /// How many different types of `CastleRights` are there?
-#[allow(dead_code)]
 pub const NUM_CASTLE_RIGHTS: usize = 4;
 
 /// Enumerate all castle rights.
-#[allow(dead_code)]
 pub const ALL_CASTLE_RIGHTS: [CastleRights; NUM_CASTLE_RIGHTS] = [CastleRights::NoRights, CastleRights::KingSide, CastleRights::QueenSide, CastleRights::Both];
 
 impl CastleRights {
     /// Can I castle kingside?
-    #[allow(dead_code)]
     pub fn has_kingside(&self) -> bool {
         self.to_index() & 1 == 1
     }
 
     /// Can I castle queenside?
-    #[allow(dead_code)]
     pub fn has_queenside(&self) -> bool {
         self.to_index() & 2 == 2
     }
 
     /// What squares need to be empty to castle kingside?
-    #[allow(dead_code)]
     pub fn kingside_squares(&self, color: Color) -> BitBoard {
         BitBoard::set(color.to_my_backrank(), File::F) ^
         BitBoard::set(color.to_my_backrank(), File::G)
     }
 
     /// What squares need to be empty to castle queenside?
-    #[allow(dead_code)]
     pub fn queenside_squares(&self, color: Color) -> BitBoard {
         BitBoard::set(color.to_my_backrank(), File::B) ^
         BitBoard::set(color.to_my_backrank(), File::C) ^
@@ -49,25 +42,21 @@ impl CastleRights {
     }
 
     /// Remove castle rights, and return a new `CastleRights`.
-    #[allow(dead_code)]
     pub fn remove(&self, remove: CastleRights) -> CastleRights {
         CastleRights::from_index(self.to_index() & !remove.to_index())
     }
 
     /// Add some castle rights, and return a new `CastleRights`.
-    #[allow(dead_code)]
     pub fn add(&self, add: CastleRights) -> CastleRights {
         CastleRights::from_index(self.to_index() | add.to_index())
     }
 
     /// Convert `CastleRights` to `usize` for table lookups
-    #[allow(dead_code)]
     pub fn to_index(&self) -> usize {
         *self as usize
     }
 
     /// Convert `usize` to `CastleRights`.  Panic if invalid number.
-    #[allow(dead_code)]
     pub fn from_index(i: usize) -> CastleRights {
         match i {
             0 => CastleRights::NoRights,
@@ -79,7 +68,6 @@ impl CastleRights {
     }
 
     /// Which rooks can we "guarantee" we haven't moved yet?
-    #[allow(dead_code)]
     pub fn unmoved_rooks(&self, color: Color) -> BitBoard {
         match *self {
             CastleRights::NoRights => EMPTY,
@@ -92,7 +80,6 @@ impl CastleRights {
 
     /// Given a square of a rook, which side is it on?
     /// Note: It is invalid to pass in a non-rook square.  The code may panic.
-    #[allow(dead_code)]
     pub fn rook_square_to_castle_rights(square: Square) -> CastleRights {
         match square.get_file() {
             File::A => CastleRights::QueenSide,

--- a/src/piece.rs
+++ b/src/piece.rs
@@ -2,7 +2,6 @@ use std::fmt;
 
 /// Represent a chess piece as a very simple enum
 #[derive(PartialEq, Eq, Ord, PartialOrd, Copy, Clone)]
-#[allow(dead_code)]
 pub enum Piece {
     Pawn,
     Knight,
@@ -13,31 +12,25 @@ pub enum Piece {
 }
 
 /// How many piece types are there?
-#[allow(dead_code)]
 pub const NUM_PIECES: usize = 6;
 
 /// An array representing each piece type, in order of ascending value.
-#[allow(dead_code)]
 pub const ALL_PIECES: [Piece; NUM_PIECES] = [Piece::Pawn, Piece::Knight, Piece::Bishop, Piece::Rook, Piece::Queen, Piece::King];
 
 /// How many ways can I promote?
-#[allow(dead_code)]
 pub const NUM_PROMOTION_PIECES: usize = 4;
 
 /// What pieces can I promote to?
-#[allow(dead_code)]
 pub const PROMOTION_PIECES: [Piece; 4] = [ Piece::Queen, Piece::Knight, Piece::Rook, Piece::Bishop ];
 
 impl Piece {
     /// Convert the `Piece` to a `usize` for table lookups.
-    #[allow(dead_code)]
     pub fn to_index(&self) -> usize {
         *self as usize
     }
 }
 
 impl fmt::Display for Piece {
-    #[allow(dead_code)]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", match *self {
             Piece::Pawn => "P",

--- a/src/square.rs
+++ b/src/square.rs
@@ -8,38 +8,32 @@ use std::fmt;
 pub struct Square(u8);
 
 /// How many squares are there?
-#[allow(dead_code)]
 pub const NUM_SQUARES: usize = 64;
 
 impl Square {
     /// Create a new square, given an index.
     /// Note: It is invalid, but allowed, to pass in a number >= 64.  Doing so will crash stuff.
-    #[allow(dead_code)]
     pub unsafe fn new(sq: u8) -> Square {
         Square(sq)
     }
 
     /// Make a square given a rank and a file
-    #[allow(dead_code)]
     pub fn make_square(rank: Rank, file: File) -> Square {
         Square((rank.to_index() as u8)<<3 | (file.to_index() as u8))
     }
 
 
     /// Return the rank given this square.
-    #[allow(dead_code)]
     pub fn get_rank(&self) -> Rank {
         Rank::from_index((self.0 >> 3) as usize)
     }
 
     /// Return the file given this square.
-    #[allow(dead_code)]
     pub fn get_file(&self) -> File {
         File::from_index((self.0 & 7) as usize)
     }
 
     /// If there is a square above me, return that.  Otherwise, None.
-    #[allow(dead_code)]
     pub fn up(&self) -> Option<Square> {
         if self.get_rank() == Rank::Eighth {
             None
@@ -49,7 +43,6 @@ impl Square {
     }
 
     /// If there is a square below me, return that.  Otherwise, None.
-    #[allow(dead_code)]
     pub fn down(&self) -> Option<Square> {
         if self.get_rank() == Rank::First {
             None
@@ -59,7 +52,6 @@ impl Square {
     }
 
     /// If there is a square to the left of me, return that.  Otherwise, None.
-    #[allow(dead_code)]
     pub fn left(&self) -> Option<Square> {
         if self.get_file() == File::A {
             None
@@ -69,7 +61,6 @@ impl Square {
     }
 
     /// If there is a square to the right of me, return that.  Otherwise, None.
-    #[allow(dead_code)]
     pub fn right(&self) -> Option<Square> {
         if self.get_file() == File::H {
             None
@@ -79,7 +70,6 @@ impl Square {
     }
 
     /// If there is a square "forward", given my `Color`, go in that direction.  Otherwise, None.
-    #[allow(dead_code)]
     pub fn forward(&self, color: Color) -> Option<Square> {
         match color {
             Color::White => self.up(),
@@ -88,7 +78,6 @@ impl Square {
     }
 
     /// If there is a square "backward" given my `Color`, go in that direction.  Otherwise, None.
-    #[allow(dead_code)]
     pub fn backward(&self, color: Color) -> Option<Square> {
         match color {
             Color::White => self.down(),
@@ -98,33 +87,28 @@ impl Square {
 
 
     /// If there is a square above me, return that.  If not, wrap around to the other side.
-    #[allow(dead_code)]
     pub fn uup(&self) -> Square {
         Square::make_square(self.get_rank().up(), self.get_file())
     }
 
     /// If there is a square below me, return that.  If not, wrap around to the other side.
-    #[allow(dead_code)]
     pub fn udown(&self) -> Square {
         Square::make_square(self.get_rank().down(), self.get_file())
     }
 
     /// If there is a square to the left of me, return that. If not, wrap around to the other side.
-    #[allow(dead_code)]
     pub fn uleft(&self) -> Square {
         Square::make_square(self.get_rank(), self.get_file().left())
     }
 
     /// If there is a square to the right of me, return that.  If not, wrap around to the other
     /// side.
-    #[allow(dead_code)]
     pub fn uright(&self) -> Square {
         Square::make_square(self.get_rank(), self.get_file().right())
     }
 
     /// If there is a square "forward", given my color, return that.  If not, wrap around to the
     /// other side.
-    #[allow(dead_code)]
     pub fn uforward(&self, color: Color) -> Square {
         match color {
             Color::White => self.uup(),
@@ -134,7 +118,6 @@ impl Square {
 
     /// If there is a square "backward", given my color, return that.  If not, wrap around to the
     /// other side.
-    #[allow(dead_code)]
     pub fn ubackward(&self, color: Color) -> Square {
         match color {
             Color::White => self.udown(),
@@ -143,19 +126,16 @@ impl Square {
     }
 
     /// Convert this square to an integer.
-    #[allow(dead_code)]
     pub fn to_int(&self) -> u8 {
         self.0
     }
 
     /// Convert this `Square` to a `usize` for table lookup purposes
-    #[allow(dead_code)]
     pub fn to_index(&self) -> usize {
         self.0 as usize
     }
 
     /// Convert a UCI `String` to a square.  If invalid, return `None`
-    #[allow(dead_code)]
     pub fn from_string(s: String) -> Option<Square> {
         if s.len() != 2 {
             return None;
@@ -174,7 +154,6 @@ impl Square {
     }
 }
 impl fmt::Display for Square {
-    #[allow(dead_code)]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}{}", (('a' as u8) + ((self.0 & 7) as u8)) as char,
                           (('1' as u8) + ((self.0 >> 3) as u8)) as char)
@@ -182,7 +161,6 @@ impl fmt::Display for Square {
 }
  
 /// A list of every square on the chessboard.
-#[allow(dead_code)]
 pub const ALL_SQUARES: [Square; 64] = [
      Square(0),  Square(1),  Square(2),  Square(3),  Square(4),  Square(5),  Square(6), Square(7),
      Square(8),  Square(9), Square(10), Square(11), Square(12), Square(13), Square(14), Square(15),


### PR DESCRIPTION
The dead code warnings are coming from the build script. On the other
hand public methods in libraries can never be dead code. Let's just
ignore dead code warnings in build.rs instead of all over the place.