### PR TITLE
Add micro benchmarks for move gen and making

### DIFF
--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -3,9 +3,10 @@ extern crate bencher;
 extern crate chess;
 
 use bencher::Bencher;
-use chess::Board;
+use chess::{Board, ChessMove, Color, ALL_SQUARES};
 
 const INITIAL_FEN: &str = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
+const MIDDLEGAME_FEN: &str = "rn1qkb1r/pbp2ppp/1p2p3/3n4/8/2N2NP1/PP1PPPBP/R1BQ1RK1 b kq - 1 7";
 
 fn perft_4(bench: &mut Bencher) {
     let pos = Board::from_fen(INITIAL_FEN.to_owned()).expect("valid fen");
@@ -17,5 +18,22 @@ fn perft_5(bench: &mut Bencher) {
     bench.iter(|| assert_eq!(pos.perft(5), 4865609));
 }
 
-benchmark_group!(benches, perft_4, perft_5);
+fn enumerate_moves(bench: &mut Bencher) {
+    let pos = Board::from_fen(MIDDLEGAME_FEN.to_owned()).expect("valid fen");
+    bench.iter(|| {
+        let mut moves = [ChessMove::new(ALL_SQUARES[0], ALL_SQUARES[0], None); 256];
+        assert_eq!(pos.enumerate_moves(&mut moves), 39);
+    });
+}
+
+fn make_move(bench: &mut Bencher) {
+    let pos = Board::from_fen(MIDDLEGAME_FEN.to_owned()).expect("valid fen");
+    let m = ChessMove::new(ALL_SQUARES[61], ALL_SQUARES[52], None);
+    bench.iter(|| {
+       let after = pos.make_move(m);
+       assert_eq!(after.side_to_move(), Color::White);
+    });
+}
+
+benchmark_group!(benches, perft_4, perft_5, enumerate_moves, make_move);
 benchmark_main!(benches);

--- a/src/color.rs
+++ b/src/color.rs
@@ -2,7 +2,7 @@ use std::ops::Not;
 use rank::Rank;
 
 /// Represent a color.
-#[derive(PartialOrd, PartialEq, Copy, Clone)]
+#[derive(PartialOrd, PartialEq, Copy, Clone, Debug)]
 pub enum Color {
     White,
     Black


### PR DESCRIPTION
Some more lower level benchmarks.

Baseline performance:

```
test enumerate_moves ... bench:         139 ns/iter (+/- 13)
test make_move       ... bench:          19 ns/iter (+/- 2)
test perft_4         ... bench:   1,133,459 ns/iter (+/- 71,360)
test perft_5         ... bench:  27,364,161 ns/iter (+/- 1,461,357)
```