### PR TITLE
Hash eq board

### DIFF
--- a/src/bitboard.rs
+++ b/src/bitboard.rs
@@ -23,7 +23,7 @@ use std::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, M
 /// assert_eq!(count, 3);
 /// ```
 ///
-#[derive(PartialEq, PartialOrd, Clone, Copy, Debug, Default)]
+#[derive(PartialEq, Eq, PartialOrd, Clone, Copy, Debug, Default, Hash)]
 pub struct BitBoard(pub u64);
 
 /// An empty bitboard.  It is sometimes useful to use !EMPTY to get the universe of squares.

--- a/src/board.rs
+++ b/src/board.rs
@@ -16,6 +16,7 @@ use crate::square::{Square, ALL_SQUARES};
 use crate::zobrist::Zobrist;
 use std::convert::{TryFrom, TryInto};
 use std::fmt;
+use std::hash::{Hash, Hasher};
 use std::mem;
 use std::str::FromStr;
 
@@ -47,6 +48,12 @@ impl Default for Board {
     fn default() -> Board {
         Board::from_str("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1")
             .expect("Valid Position")
+    }
+}
+
+impl Hash for Board {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.hash.hash(state);
     }
 }
 

--- a/src/board.rs
+++ b/src/board.rs
@@ -21,7 +21,7 @@ use std::mem;
 use std::str::FromStr;
 
 /// A representation of a chess board.  That's why you're here, right?
-#[derive(Copy, Clone, PartialEq, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub struct Board {
     pieces: [BitBoard; NUM_PIECES],
     color_combined: [BitBoard; NUM_COLORS],

--- a/src/castle_rights.rs
+++ b/src/castle_rights.rs
@@ -8,7 +8,7 @@ use crate::square::Square;
 use crate::magic::{KINGSIDE_CASTLE_SQUARES, QUEENSIDE_CASTLE_SQUARES};
 
 /// What castle rights does a particular player have?
-#[derive(Copy, Clone, PartialEq, PartialOrd, Debug, Hash)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Debug, Hash)]
 pub enum CastleRights {
     NoRights,
     KingSide,

--- a/src/file.rs
+++ b/src/file.rs
@@ -3,7 +3,7 @@ use std::mem::transmute;
 use std::str::FromStr;
 
 /// Describe a file (column) on a chess board
-#[derive(Copy, Clone, PartialEq, PartialOrd, Debug, Hash)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Debug, Hash)]
 pub enum File {
     A,
     B,

--- a/src/rank.rs
+++ b/src/rank.rs
@@ -3,7 +3,7 @@ use std::mem::transmute;
 use std::str::FromStr;
 
 /// Describe a rank (row) on a chess board
-#[derive(Copy, Clone, PartialEq, PartialOrd, Debug, Hash)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Debug, Hash)]
 pub enum Rank {
     First,
     Second,


### PR DESCRIPTION
Solves #44 

This PR makes `Board` possible to use as the key of a standard Rust `HashMap`.
Most of the changes are additions to `#[derive]` attribute for the types.

Of note is the `impl Hash for Board`. The `hash` function does not return its result and instead has a `&mut Hasher` parameter to hold the state of the hash. The current solution is to only hash `self.hash`. This is faster than the `#[derive]`, as it is only one field, but I do not know the implications of using a hash _of_ a hash.