### PR TITLE
Remove unnecessary conversion when creating square

### DIFF
--- a/src/square.rs
+++ b/src/square.rs
@@ -69,7 +69,7 @@ impl Square {
     /// ```
     #[inline]
     pub fn make_square(rank: Rank, file: File) -> Square {
-        Square((rank.to_index() as u8) << 3 ^ (file.to_index() as u8))
+        Square((rank as u8) << 3 ^ (file as u8))
     }
 
     /// Return the rank given this square.


### PR DESCRIPTION
Unless the usize conversion was intended, we can convert directly to u8.