### PR TITLE
Hotfix for unsoundness issue with MoveGen (55)

### DIFF
--- a/src/movegen/movegen.rs
+++ b/src/movegen/movegen.rs
@@ -525,6 +525,11 @@ fn movegen_issue_15() {
     let _ = MoveGen::new_legal(&board);
 }
 
+#[test]
+fn movegen_issue_55() {
+    MoveGen::new_legal(&"3k4/8/PPPPPPPP/8/PPPPPPPP/8/PPPPPPPP/3K4 w - - 0 1".parse().unwrap());
+}
+
 #[cfg(test)]
 fn move_of(m: &str) -> ChessMove {
     let promo = if m.len() > 4 {


### PR DESCRIPTION
See #55 

I solved this by ignoring moves that do not fit in the list. The performance impact of this solution should be minimal because the branch predictor should be able to guess right and it should only introduce an additional conditional jump instruction. I did not measure anything though.

A clean fix would either require a `SmallVec` (probably best with a specialized happy path that does the same as above) or a `ExpectedBoard` or `ValidBoard` like type that upholds certain invariants.