### PR TITLE
add MoveGen::has_legal_moves and use it in Board.status

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -155,16 +155,14 @@ impl Board {
     /// ```
     #[inline]
     pub fn status(&self) -> BoardStatus {
-        let moves = MoveGen::new_legal(&self).len();
-        match moves {
-            0 => {
-                if self.checkers == EMPTY {
-                    BoardStatus::Stalemate
-                } else {
-                    BoardStatus::Checkmate
-                }
+        if MoveGen::has_legal_moves(&self) {
+            BoardStatus::Ongoing
+        } else {
+            if self.checkers == EMPTY {
+                BoardStatus::Stalemate
+            } else {
+                BoardStatus::Checkmate
             }
-            _ => BoardStatus::Ongoing,
         }
     }
 


### PR DESCRIPTION
Resolves #63.

Added associated method ```MoveGen::has_legal_moves(&Board) -> bool```, which short-circuits if a legal move is found. Also sped up ```Board.status``` using this method.