### PR TITLE
Enable optimization on the build script no matter which profile is used for the crate itself. This should fix #58.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,14 @@ debug = true
 [profile.test]
 opt-level = 3
 
+# always optimize build script, because it takes a long time to run unoptimized
+[profile.dev.build-override]
+opt-level = 3
+[profile.release.build-override]
+opt-level = 3
+[profile.test.build-override]
+opt-level = 3
+
 [build-dependencies]
 rand = { version = "0.7.2", default_features = false, features = ["small_rng"] }
 failure = "0.1.6"


### PR DESCRIPTION
Cargo by default does not optimizer the build script, but it's easy to change that setting, see https://doc.rust-lang.org/cargo/reference/profiles.html#build-dependencies.