### PR TITLE
Updating to modern Rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chess"
-version = "3.2.0"
+version = "3.3.0"
 edition = "2018"
 authors = ["Jordan Bray <jordanbray@gmail.com>"]
 description = "This is a fast chess move generator.  It has a very good set of documentation, so you should take advantage of that.  It (now) generates all lookup tables with a build.rs file, which means that very little pseudo-legal move generation requires branching.  There are some convenience functions that are exposed to, for example, find all the squares between two squares.  This uses a copy-on-make style structure, and the Board structure is as slimmed down as possible to reduce the cost of copying the board.  There are places to improve perft-test performance further, but I instead opt to be more feature-complete to make it useful in real applications.  For example, I generate both a hash of the board and a pawn-hash of the board for use in evaluation lookup tables (using Zobrist hashing).  There are two ways to generate moves, one is faster, the other has more features that will be useful if making a chess engine.  See the documentation for more details."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ documentation = "https://jordanbray.github.io/chess/chess/index.html"
 [dependencies]
 arrayvec = "0.7.2"
 nodrop = "0.1.14"
-failure = "0.1.6"
+thiserror = "1.0.44"
 
 [profile.release]
 opt-level = 3
@@ -39,5 +39,5 @@ opt-level = 3
 opt-level = 3
 
 [build-dependencies]
-rand = { version = "0.7.2", default_features = false, features = ["small_rng"] }
-failure = "0.1.6"
+rand = { version = "0.7.2", default-features = false, features = ["small_rng"] }
+thiserror = "1.0.44"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,11 @@ readme = "README.md"
 keywords = ["chess", "move", "generator"]
 license = "MIT"
 documentation = "https://jordanbray.github.io/chess/chess/index.html"
+rust-version = "1.56.0"
 
 [dependencies]
 arrayvec = "0.7.2"
+const_for = "0.1.2"
 nodrop = "0.1.14"
 thiserror = "1.0.44"
 
@@ -39,5 +41,6 @@ opt-level = 3
 opt-level = 3
 
 [build-dependencies]
+const_for = "0.1.2"
 rand = { version = "0.7.2", default-features = false, features = ["small_rng"] }
 thiserror = "1.0.44"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "chess"
 version = "3.3.0"
-edition = "2018"
+edition = "2021"
 authors = ["Jordan Bray <jordanbray@gmail.com>"]
 description = "This is a fast chess move generator.  It has a very good set of documentation, so you should take advantage of that.  It (now) generates all lookup tables with a build.rs file, which means that very little pseudo-legal move generation requires branching.  There are some convenience functions that are exposed to, for example, find all the squares between two squares.  This uses a copy-on-make style structure, and the Board structure is as slimmed down as possible to reduce the cost of copying the board.  There are places to improve perft-test performance further, but I instead opt to be more feature-complete to make it useful in real applications.  For example, I generate both a hash of the board and a pawn-hash of the board for use in evaluation lookup tables (using Zobrist hashing).  There are two ways to generate moves, one is faster, the other has more features that will be useful if making a chess engine.  See the documentation for more details."
 build = "src/build.rs"
@@ -21,6 +21,7 @@ failure = "0.1.6"
 [profile.release]
 opt-level = 3
 debug = false
+lto = "yes"
 
 [profile.dev]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chess"
-version = "3.3.0"
+version = "4.0.0"
 edition = "2021"
 authors = ["Jordan Bray <jordanbray@gmail.com>"]
 description = "This is a fast chess move generator.  It has a very good set of documentation, so you should take advantage of that.  It (now) generates all lookup tables with a build.rs file, which means that very little pseudo-legal move generation requires branching.  There are some convenience functions that are exposed to, for example, find all the squares between two squares.  This uses a copy-on-make style structure, and the Board structure is as slimmed down as possible to reduce the cost of copying the board.  There are places to improve perft-test performance further, but I instead opt to be more feature-complete to make it useful in real applications.  For example, I generate both a hash of the board and a pawn-hash of the board for use in evaluation lookup tables (using Zobrist hashing).  There are two ways to generate moves, one is faster, the other has more features that will be useful if making a chess engine.  See the documentation for more details."

--- a/src/bitboard.rs
+++ b/src/bitboard.rs
@@ -262,7 +262,7 @@ impl fmt::Display for BitBoard {
                 s.push_str(". ");
             }
             if x % 8 == 7 {
-                s.push_str("\n");
+                s.push('\n');
             }
         }
         write!(f, "{}", s)
@@ -292,7 +292,7 @@ impl BitBoard {
     #[inline]
     #[deprecated(since = "3.3.0", note = "Method is considered an unnecessary shorthand for `square_option.map(BitBoard::from_square)`.")]
     pub fn from_maybe_square(sq: Option<Square>) -> Option<BitBoard> {
-        sq.map(|s| BitBoard::from_square(s))
+        sq.map(BitBoard::from_square)
     }
 
     /// Convert a `BitBoard` to a `Square`.  This grabs the least-significant `Square`

--- a/src/bitboard.rs
+++ b/src/bitboard.rs
@@ -297,7 +297,7 @@ impl BitBoard {
 
     /// Convert a `BitBoard` to a `Square`.  This grabs the least-significant `Square`
     #[inline]
-    pub const fn to_square(&self) -> Square {
+    pub const fn to_square(self) -> Square {
         Square::new(self.0.trailing_zeros() as u8)
     }
 
@@ -315,7 +315,7 @@ impl BitBoard {
 
     /// Convert this `BitBoard` to a `usize` (for table lookups)
     #[inline]
-    pub const fn to_size(&self, rightshift: u8) -> usize {
+    pub const fn to_size(self, rightshift: u8) -> usize {
         (self.0 >> rightshift) as usize
     }
 }

--- a/src/bitboard.rs
+++ b/src/bitboard.rs
@@ -1,3 +1,5 @@
+use const_for::const_for;
+
 use crate::file::File;
 use crate::rank::Rank;
 use crate::square::*;
@@ -290,7 +292,10 @@ impl BitBoard {
 
     /// Convert an `Option<Square>` to an `Option<BitBoard>`
     #[inline]
-    #[deprecated(since = "3.3.0", note = "Method is considered an unnecessary shorthand for `square_option.map(BitBoard::from_square)`.")]
+    #[deprecated(
+        since = "3.3.0",
+        note = "Method is considered an unnecessary shorthand for `square_option.map(BitBoard::from_square)`."
+    )]
     pub fn from_maybe_square(sq: Option<Square>) -> Option<BitBoard> {
         sq.map(BitBoard::from_square)
     }
@@ -317,6 +322,17 @@ impl BitBoard {
     #[inline]
     pub const fn to_size(self, rightshift: u8) -> usize {
         (self.0 >> rightshift) as usize
+    }
+
+    pub(crate) const fn from_array(arr: [u64; 8]) -> Self {
+        let mut accum = 0;
+
+        const_for!(i in 0..8 => {
+            accum <<= 8;
+            accum |= arr[i];
+        });
+
+        BitBoard::new(accum)
     }
 }
 

--- a/src/bitboard.rs
+++ b/src/bitboard.rs
@@ -293,7 +293,7 @@ impl BitBoard {
     /// Convert an `Option<Square>` to an `Option<BitBoard>`
     #[inline]
     #[deprecated(
-        since = "3.3.0",
+        since = "4.0.0",
         note = "Method is considered an unnecessary shorthand for `square_option.map(BitBoard::from_square)`."
     )]
     pub fn from_maybe_square(sq: Option<Square>) -> Option<BitBoard> {

--- a/src/bitboard.rs
+++ b/src/bitboard.rs
@@ -272,49 +272,50 @@ impl fmt::Display for BitBoard {
 impl BitBoard {
     /// Construct a new bitboard from a u64
     #[inline]
-    pub fn new(b: u64) -> BitBoard {
+    pub const fn new(b: u64) -> BitBoard {
         BitBoard(b)
     }
 
     /// Construct a new `BitBoard` with a particular `Square` set
     #[inline]
-    pub fn set(rank: Rank, file: File) -> BitBoard {
+    pub const fn set(rank: Rank, file: File) -> BitBoard {
         BitBoard::from_square(Square::make_square(rank, file))
     }
 
     /// Construct a new `BitBoard` with a particular `Square` set
     #[inline]
-    pub fn from_square(sq: Square) -> BitBoard {
+    pub const fn from_square(sq: Square) -> BitBoard {
         BitBoard(1u64 << sq.to_int())
     }
 
     /// Convert an `Option<Square>` to an `Option<BitBoard>`
     #[inline]
+    #[deprecated(since = "3.3.0", note = "Method is considered an unnecessary shorthand for `square_option.map(BitBoard::from_square)`.")]
     pub fn from_maybe_square(sq: Option<Square>) -> Option<BitBoard> {
         sq.map(|s| BitBoard::from_square(s))
     }
 
     /// Convert a `BitBoard` to a `Square`.  This grabs the least-significant `Square`
     #[inline]
-    pub fn to_square(&self) -> Square {
+    pub const fn to_square(&self) -> Square {
         Square::new(self.0.trailing_zeros() as u8)
     }
 
     /// Count the number of `Squares` set in this `BitBoard`
     #[inline]
-    pub fn popcnt(&self) -> u32 {
+    pub const fn popcnt(&self) -> u32 {
         self.0.count_ones()
     }
 
     /// Reverse this `BitBoard`.  Look at it from the opponents perspective.
     #[inline]
-    pub fn reverse_colors(&self) -> BitBoard {
+    pub const fn reverse_colors(&self) -> BitBoard {
         BitBoard(self.0.swap_bytes())
     }
 
     /// Convert this `BitBoard` to a `usize` (for table lookups)
     #[inline]
-    pub fn to_size(&self, rightshift: u8) -> usize {
+    pub const fn to_size(&self, rightshift: u8) -> usize {
         (self.0 >> rightshift) as usize
     }
 }

--- a/src/board.rs
+++ b/src/board.rs
@@ -17,7 +17,7 @@ use crate::zobrist::Zobrist;
 use std::convert::{TryFrom, TryInto};
 use std::fmt;
 use std::hash::{Hash, Hasher};
-use std::mem;
+
 use std::str::FromStr;
 
 /// A representation of a chess board.  That's why you're here, right?
@@ -35,6 +35,7 @@ pub struct Board {
 }
 
 /// What is the status of this game?
+#[repr(u8)]
 #[derive(Copy, Clone, PartialEq, PartialOrd, Debug)]
 pub enum BoardStatus {
     Ongoing,
@@ -60,7 +61,7 @@ impl Hash for Board {
 impl Board {
     /// Construct a new `Board` that is completely empty.
     /// Note: This does NOT give you the initial position.  Just a blank slate.
-    fn new() -> Board {
+    const fn new() -> Board {
         Board {
             pieces: [EMPTY; NUM_PIECES],
             color_combined: [EMPTY; NUM_COLORS],
@@ -73,6 +74,7 @@ impl Board {
             en_passant: None,
         }
     }
+
 
     /// Construct a board from a FEN string.
     ///
@@ -183,7 +185,7 @@ impl Board {
     /// assert_eq!(*board.combined(), combined_should_be);
     /// ```
     #[inline]
-    pub fn combined(&self) -> &BitBoard {
+    pub const fn combined(&self) -> &BitBoard {
         &self.combined
     }
 
@@ -328,7 +330,7 @@ impl Board {
     /// assert_eq!(board.side_to_move(), Color::White);
     /// ```
     #[inline]
-    pub fn side_to_move(&self) -> Color {
+    pub const fn side_to_move(&self) -> Color {
         self.side_to_move
     }
 
@@ -803,7 +805,7 @@ impl Board {
     /// assert_eq!(board.en_passant(), Some(Square::E5));
     /// ```
     #[inline]
-    pub fn en_passant(self) -> Option<Square> {
+    pub const fn en_passant(self) -> Option<Square> {
         self.en_passant
     }
 

--- a/src/board.rs
+++ b/src/board.rs
@@ -157,7 +157,7 @@ impl Board {
     /// ```
     #[inline]
     pub fn status(&self) -> BoardStatus {
-        let moves = MoveGen::new_legal(&self).len();
+        let moves = MoveGen::new_legal(self).len();
         match moves {
             0 => {
                 if self.checkers == EMPTY {
@@ -591,10 +591,8 @@ impl Board {
         // make sure there is no square with multiple pieces on it
         for x in ALL_PIECES.iter() {
             for y in ALL_PIECES.iter() {
-                if *x != *y {
-                    if self.pieces(*x) & self.pieces(*y) != EMPTY {
-                        return false;
-                    }
+                if *x != *y && self.pieces(*x) & self.pieces(*y) != EMPTY {
+                    return false;
                 }
             }
         }
@@ -663,12 +661,8 @@ impl Board {
             }
             // if we have castle rights, make sure we have a king on the (E, {1,8}) square,
             // depending on the color
-            if castle_rights != CastleRights::NoRights {
-                if self.pieces(Piece::King) & self.color_combined(*color)
-                    != get_file(File::E) & get_rank(color.to_my_backrank())
-                {
-                    return false;
-                }
+            if castle_rights != CastleRights::NoRights && self.pieces(Piece::King) & self.color_combined(*color) != get_file(File::E) & get_rank(color.to_my_backrank()) {
+                return false;
             }
         }
 
@@ -678,7 +672,7 @@ impl Board {
         }
 
         // it checks out
-        return true;
+        true
     }
 
     /// Get a hash of the board.
@@ -747,14 +741,12 @@ impl Board {
                 } else {
                     Some(Piece::Bishop)
                 }
+            } else if self.pieces(Piece::Rook) & opp != EMPTY {
+                Some(Piece::Rook)
+            } else if self.pieces(Piece::Queen) & opp != EMPTY {
+                Some(Piece::Queen)
             } else {
-                if self.pieces(Piece::Rook) & opp != EMPTY {
-                    Some(Piece::Rook)
-                } else if self.pieces(Piece::Queen) & opp != EMPTY {
-                    Some(Piece::Queen)
-                } else {
-                    Some(Piece::King)
-                }
+                Some(Piece::King)
             }
         }
     }
@@ -844,7 +836,7 @@ impl Board {
     /// ```
     #[inline]
     pub fn legal(&self, m: ChessMove) -> bool {
-        MoveGen::new_legal(&self).find(|x| *x == m).is_some()
+        MoveGen::new_legal(self).any(|x| x == m)
     }
 
     /// Make a chess move onto a new board.
@@ -1214,7 +1206,7 @@ impl FromStr for Board {
     type Err = Error;
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
-        Ok(BoardBuilder::from_str(value)?.try_into()?)
+        BoardBuilder::from_str(value)?.try_into()
     }
 }
 

--- a/src/board.rs
+++ b/src/board.rs
@@ -3,7 +3,7 @@ use crate::board_builder::BoardBuilder;
 use crate::castle_rights::CastleRights;
 use crate::chess_move::ChessMove;
 use crate::color::{Color, ALL_COLORS, NUM_COLORS};
-use crate::error::Error;
+use crate::error::InvalidError;
 use crate::file::File;
 use crate::magic::{
     between, get_adjacent_files, get_bishop_rays, get_castle_moves, get_file, get_king_moves,
@@ -1152,7 +1152,7 @@ impl fmt::Display for Board {
 }
 
 impl TryFrom<&BoardBuilder> for Board {
-    type Error = Error;
+    type Error = InvalidError;
 
     fn try_from(fen: &BoardBuilder) -> Result<Self, Self::Error> {
         let mut board = Board::new();
@@ -1181,13 +1181,13 @@ impl TryFrom<&BoardBuilder> for Board {
         if board.is_sane() {
             Ok(board)
         } else {
-            Err(Error::InvalidBoard)
+            Err(InvalidError::Board)
         }
     }
 }
 
 impl TryFrom<&mut BoardBuilder> for Board {
-    type Error = Error;
+    type Error = InvalidError;
 
     fn try_from(fen: &mut BoardBuilder) -> Result<Self, Self::Error> {
         (&*fen).try_into()
@@ -1195,7 +1195,7 @@ impl TryFrom<&mut BoardBuilder> for Board {
 }
 
 impl TryFrom<BoardBuilder> for Board {
-    type Error = Error;
+    type Error = InvalidError;
 
     fn try_from(fen: BoardBuilder) -> Result<Self, Self::Error> {
         (&fen).try_into()
@@ -1203,7 +1203,7 @@ impl TryFrom<BoardBuilder> for Board {
 }
 
 impl FromStr for Board {
-    type Err = Error;
+    type Err = InvalidError;
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
         BoardBuilder::from_str(value)?.try_into()

--- a/src/board_builder.rs
+++ b/src/board_builder.rs
@@ -1,7 +1,7 @@
 use crate::board::Board;
 use crate::castle_rights::CastleRights;
 use crate::color::Color;
-use crate::error::Error;
+use crate::error::InvalidError;
 use crate::file::{File, ALL_FILES};
 use crate::piece::Piece;
 use crate::rank::{Rank, ALL_RANKS};
@@ -346,7 +346,7 @@ impl Default for BoardBuilder {
 }
 
 impl FromStr for BoardBuilder {
-    type Err = Error;
+    type Err = InvalidError;
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
         let mut cur_rank = Rank::Eighth;
@@ -355,7 +355,7 @@ impl FromStr for BoardBuilder {
 
         let tokens: Vec<&str> = value.split(' ').collect();
         if tokens.len() < 4 {
-            return Err(Error::InvalidFen {
+            return Err(InvalidError::Fen {
                 fen: value.to_string(),
             });
         }
@@ -436,7 +436,7 @@ impl FromStr for BoardBuilder {
                     cur_file = cur_file.right();
                 }
                 _ => {
-                    return Err(Error::InvalidFen {
+                    return Err(InvalidError::Fen {
                         fen: value.to_string(),
                     });
                 }
@@ -446,7 +446,7 @@ impl FromStr for BoardBuilder {
             "w" | "W" => fen = fen.side_to_move(Color::White),
             "b" | "B" => fen = fen.side_to_move(Color::Black),
             _ => {
-                return Err(Error::InvalidFen {
+                return Err(InvalidError::Fen {
                     fen: value.to_string(),
                 })
             }

--- a/src/board_builder.rs
+++ b/src/board_builder.rs
@@ -179,7 +179,7 @@ impl BoardBuilder {
     /// let mut bb = BoardBuilder::new();
     /// bb.side_to_move(Color::Black);
     /// ```
-    pub fn side_to_move<'a>(&'a mut self, color: Color) -> &'a mut Self {
+    pub fn side_to_move(&mut self, color: Color) -> &mut Self {
         self.side_to_move = color;
         self
     }
@@ -196,11 +196,11 @@ impl BoardBuilder {
     /// let mut bb = BoardBuilder::new();
     /// bb.castle_rights(Color::Black, CastleRights::Both);
     /// ```
-    pub fn castle_rights<'a>(
-        &'a mut self,
+    pub fn castle_rights(
+        &mut self,
         color: Color,
         castle_rights: CastleRights,
-    ) -> &'a mut Self {
+    ) -> &mut Self {
         self.castle_rights[color.to_index()] = castle_rights;
         self
     }
@@ -222,7 +222,7 @@ impl BoardBuilder {
     /// let mut bb = BoardBuilder::new();
     /// bb.piece(Square::A8, Piece::Rook, Color::Black);
     /// ```
-    pub fn piece<'a>(&'a mut self, square: Square, piece: Piece, color: Color) -> &'a mut Self {
+    pub fn piece(&mut self, square: Square, piece: Piece, color: Color) -> &mut Self {
         self[square] = Some((piece, color));
         self
     }
@@ -239,7 +239,7 @@ impl BoardBuilder {
     /// let mut bb: BoardBuilder = Board::default().into();
     /// bb.clear_square(Square::A1);
     /// ```
-    pub fn clear_square<'a>(&'a mut self, square: Square) -> &'a mut Self {
+    pub fn clear_square(&mut self, square: Square) -> &mut Self {
         self[square] = None;
         self
     }
@@ -255,7 +255,7 @@ impl BoardBuilder {
     ///              .piece(Square::E4, Piece::Pawn, Color::White)
     ///              .en_passant(Some(File::E));
     /// ```
-    pub fn en_passant<'a>(&'a mut self, file: Option<File>) -> &'a mut Self {
+    pub fn en_passant(&mut self, file: Option<File>) -> &mut Self {
         self.en_passant = file;
         self
     }
@@ -264,13 +264,13 @@ impl BoardBuilder {
 impl Index<Square> for BoardBuilder {
     type Output = Option<(Piece, Color)>;
 
-    fn index<'a>(&'a self, index: Square) -> &'a Self::Output {
+    fn index(&self, index: Square) -> &Self::Output {
         &self.pieces[index.to_index()]
     }
 }
 
 impl IndexMut<Square> for BoardBuilder {
-    fn index_mut<'a>(&'a mut self, index: Square) -> &'a mut Self::Output {
+    fn index_mut(&mut self, index: Square) -> &mut Self::Output {
         &mut self.pieces[index.to_index()]
     }
 }
@@ -452,27 +452,27 @@ impl FromStr for BoardBuilder {
             }
         }
 
-        if castles.contains("K") && castles.contains("Q") {
+        if castles.contains('K') && castles.contains('Q') {
             fen.castle_rights[Color::White.to_index()] = CastleRights::Both;
-        } else if castles.contains("K") {
+        } else if castles.contains('K') {
             fen.castle_rights[Color::White.to_index()] = CastleRights::KingSide;
-        } else if castles.contains("Q") {
+        } else if castles.contains('Q') {
             fen.castle_rights[Color::White.to_index()] = CastleRights::QueenSide;
         } else {
             fen.castle_rights[Color::White.to_index()] = CastleRights::NoRights;
         }
 
-        if castles.contains("k") && castles.contains("q") {
+        if castles.contains('k') && castles.contains('q') {
             fen.castle_rights[Color::Black.to_index()] = CastleRights::Both;
-        } else if castles.contains("k") {
+        } else if castles.contains('k') {
             fen.castle_rights[Color::Black.to_index()] = CastleRights::KingSide;
-        } else if castles.contains("q") {
+        } else if castles.contains('q') {
             fen.castle_rights[Color::Black.to_index()] = CastleRights::QueenSide;
         } else {
             fen.castle_rights[Color::Black.to_index()] = CastleRights::NoRights;
         }
 
-        if let Ok(sq) = Square::from_str(&ep) {
+        if let Ok(sq) = Square::from_str(ep) {
             fen = fen.en_passant(Some(sq.get_file()));
         }
 

--- a/src/board_builder.rs
+++ b/src/board_builder.rs
@@ -75,7 +75,7 @@ impl BoardBuilder {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn new() -> BoardBuilder {
+    pub const fn new() -> BoardBuilder {
         BoardBuilder {
             pieces: [None; 64],
             side_to_move: Color::White,
@@ -113,9 +113,9 @@ impl BoardBuilder {
     ) -> BoardBuilder {
         let mut result = BoardBuilder {
             pieces: [None; 64],
-            side_to_move: side_to_move,
+            side_to_move,
             castle_rights: [white_castle_rights, black_castle_rights],
-            en_passant: en_passant,
+            en_passant,
         };
 
         for piece in pieces.into_iter() {
@@ -133,7 +133,7 @@ impl BoardBuilder {
     /// let bb: BoardBuilder = Board::default().into();
     /// assert_eq!(bb.get_side_to_move(), Color::White);
     /// ```
-    pub fn get_side_to_move(&self) -> Color {
+    pub const fn get_side_to_move(&self) -> Color {
         self.side_to_move
     }
 
@@ -145,7 +145,7 @@ impl BoardBuilder {
     /// let bb: BoardBuilder = Board::default().into();
     /// assert_eq!(bb.get_castle_rights(Color::White), CastleRights::Both);
     /// ```
-    pub fn get_castle_rights(&self, color: Color) -> CastleRights {
+    pub const fn get_castle_rights(&self, color: Color) -> CastleRights {
         self.castle_rights[color.to_index()]
     }
 

--- a/src/board_builder.rs
+++ b/src/board_builder.rs
@@ -196,11 +196,7 @@ impl BoardBuilder {
     /// let mut bb = BoardBuilder::new();
     /// bb.castle_rights(Color::Black, CastleRights::Both);
     /// ```
-    pub fn castle_rights(
-        &mut self,
-        color: Color,
-        castle_rights: CastleRights,
-    ) -> &mut Self {
+    pub fn castle_rights(&mut self, color: Color, castle_rights: CastleRights) -> &mut Self {
         self.castle_rights[color.to_index()] = castle_rights;
         self
     }

--- a/src/build.rs
+++ b/src/build.rs
@@ -5,7 +5,6 @@
 #![allow(dead_code)]
 
 // it to be easily followed.
-extern crate rand;
 mod bitboard;
 mod color;
 mod error;

--- a/src/cache_table.rs
+++ b/src/cache_table.rs
@@ -48,10 +48,7 @@ impl<T: Copy + Clone + PartialEq + PartialOrd> CacheTable<T> {
     #[inline]
     pub fn add(&mut self, hash: u64, entry: T) {
         let e = unsafe { self.table.get_unchecked_mut((hash as usize) & self.mask) };
-        *e = CacheTableEntry {
-            hash: hash,
-            entry: entry,
-        };
+        *e = CacheTableEntry { hash, entry };
     }
 
     /// Replace an entry in the hash table with a user-specified replacement policy specified by
@@ -82,10 +79,7 @@ impl<T: Copy + Clone + PartialEq + PartialOrd> CacheTable<T> {
     pub fn replace_if<F: Fn(T) -> bool>(&mut self, hash: u64, entry: T, replace: F) {
         let e = unsafe { self.table.get_unchecked_mut((hash as usize) & self.mask) };
         if replace(e.entry) {
-            *e = CacheTableEntry {
-                hash: hash,
-                entry: entry,
-            };
+            *e = CacheTableEntry { hash, entry };
         }
     }
 }

--- a/src/chess_move.rs
+++ b/src/chess_move.rs
@@ -22,7 +22,7 @@ pub struct ChessMove {
 }
 
 impl ChessMove {
-    /// The null move is an invalid move. It can make encoding of Option<ChessMove> more memory
+    /// The null move is an invalid move. It can make encoding of `Option<ChessMove>` more memory
     /// efficient.
     pub const NULL_MOVE: Self = Self::new(Square::A1, Square::A1, None);
 

--- a/src/chess_move.rs
+++ b/src/chess_move.rs
@@ -77,7 +77,7 @@ impl ChessMove {
                 Square::make_square(rank, dest_file),
                 None,
             );
-            if MoveGen::new_legal(&board).any(|l| l == m) {
+            if MoveGen::new_legal(board).any(|l| l == m) {
                 return Ok(m);
             } else {
                 return Err(Error::InvalidSanMove);
@@ -360,16 +360,12 @@ impl ChessMove {
             }
 
             // takes is complicated, because of e.p.
-            if !takes {
-                if board.piece_on(m.get_dest()).is_some() {
-                    continue;
-                }
+            if !takes && board.piece_on(m.get_dest()).is_some() {
+                continue;
             }
 
-            if !ep && takes {
-                if board.piece_on(m.get_dest()).is_none() {
-                    continue;
-                }
+            if !ep && takes && board.piece_on(m.get_dest()).is_none() {
+                continue;
             }
 
             found_move = Some(m);

--- a/src/chess_move.rs
+++ b/src/chess_move.rs
@@ -354,12 +354,14 @@ impl ChessMove {
                 return Err(error);
             }
 
+            let piece_exists = board.piece_on(m.get_dest()).is_some();
+
             // takes is complicated, because of e.p.
-            if !takes && board.piece_on(m.get_dest()).is_some() {
+            if !takes && piece_exists {
                 continue;
             }
 
-            if !ep && takes && board.piece_on(m.get_dest()).is_none() {
+            if !ep && takes && !piece_exists {
                 continue;
             }
 

--- a/src/chess_move.rs
+++ b/src/chess_move.rs
@@ -402,12 +402,7 @@ impl ChessMove {
         accum <<= 3;
         let prom_val = match promotion {
             None => 0,
-            Some(Piece::Pawn) => 1,
-            Some(Piece::Knight) => 2,
-            Some(Piece::Bishop) => 3,
-            Some(Piece::Rook) => 4,
-            Some(Piece::Queen) => 5,
-            Some(Piece::King) => 6,
+            Some(p) => p.to_index() as u16  + 1,
         };
         accum += prom_val;
         accum

--- a/src/color.rs
+++ b/src/color.rs
@@ -2,10 +2,11 @@ use crate::rank::Rank;
 use std::ops::Not;
 
 /// Represent a color.
+#[repr(u8)]
 #[derive(PartialOrd, PartialEq, Eq, Copy, Clone, Debug, Hash)]
 pub enum Color {
-    White,
-    Black,
+    White = 0,
+    Black = 1,
 }
 
 /// How many colors are there?
@@ -16,14 +17,14 @@ pub const ALL_COLORS: [Color; NUM_COLORS] = [Color::White, Color::Black];
 impl Color {
     /// Convert the `Color` to a `usize` for table lookups.
     #[inline]
-    pub fn to_index(&self) -> usize {
+    pub const fn to_index(&self) -> usize {
         *self as usize
     }
 
     /// Convert a `Color` to my backrank, which represents the starting rank
     /// for my pieces.
     #[inline]
-    pub fn to_my_backrank(&self) -> Rank {
+    pub const fn to_my_backrank(&self) -> Rank {
         match *self {
             Color::White => Rank::First,
             Color::Black => Rank::Eighth,
@@ -33,7 +34,7 @@ impl Color {
     /// Convert a `Color` to my opponents backrank, which represents the starting rank for the
     /// opponents pieces.
     #[inline]
-    pub fn to_their_backrank(&self) -> Rank {
+    pub const fn to_their_backrank(&self) -> Rank {
         match *self {
             Color::White => Rank::Eighth,
             Color::Black => Rank::First,
@@ -42,7 +43,7 @@ impl Color {
 
     /// Convert a `Color` to my second rank, which represents the starting rank for my pawns.
     #[inline]
-    pub fn to_second_rank(&self) -> Rank {
+    pub const fn to_second_rank(&self) -> Rank {
         match *self {
             Color::White => Rank::Second,
             Color::Black => Rank::Seventh,
@@ -52,7 +53,7 @@ impl Color {
     /// Convert a `Color` to my fourth rank, which represents the rank of my pawns when
     /// moving two squares forward.
     #[inline]
-    pub fn to_fourth_rank(&self) -> Rank {
+    pub const fn to_fourth_rank(&self) -> Rank {
         match *self {
             Color::White => Rank::Fourth,
             Color::Black => Rank::Fifth,
@@ -61,7 +62,7 @@ impl Color {
 
     /// Convert a `Color` to my seventh rank, which represents the rank before pawn promotion.
     #[inline]
-    pub fn to_seventh_rank(&self) -> Rank {
+    pub const fn to_seventh_rank(&self) -> Rank {
         match *self {
             Color::White => Rank::Seventh,
             Color::Black => Rank::Second,

--- a/src/color.rs
+++ b/src/color.rs
@@ -17,15 +17,15 @@ pub const ALL_COLORS: [Color; NUM_COLORS] = [Color::White, Color::Black];
 impl Color {
     /// Convert the `Color` to a `usize` for table lookups.
     #[inline]
-    pub const fn to_index(&self) -> usize {
-        *self as usize
+    pub const fn to_index(self) -> usize {
+        self as usize
     }
 
     /// Convert a `Color` to my backrank, which represents the starting rank
     /// for my pieces.
     #[inline]
-    pub const fn to_my_backrank(&self) -> Rank {
-        match *self {
+    pub const fn to_my_backrank(self) -> Rank {
+        match self {
             Color::White => Rank::First,
             Color::Black => Rank::Eighth,
         }
@@ -34,8 +34,8 @@ impl Color {
     /// Convert a `Color` to my opponents backrank, which represents the starting rank for the
     /// opponents pieces.
     #[inline]
-    pub const fn to_their_backrank(&self) -> Rank {
-        match *self {
+    pub const fn to_their_backrank(self) -> Rank {
+        match self {
             Color::White => Rank::Eighth,
             Color::Black => Rank::First,
         }
@@ -43,8 +43,8 @@ impl Color {
 
     /// Convert a `Color` to my second rank, which represents the starting rank for my pawns.
     #[inline]
-    pub const fn to_second_rank(&self) -> Rank {
-        match *self {
+    pub const fn to_second_rank(self) -> Rank {
+        match self {
             Color::White => Rank::Second,
             Color::Black => Rank::Seventh,
         }
@@ -53,8 +53,8 @@ impl Color {
     /// Convert a `Color` to my fourth rank, which represents the rank of my pawns when
     /// moving two squares forward.
     #[inline]
-    pub const fn to_fourth_rank(&self) -> Rank {
-        match *self {
+    pub const fn to_fourth_rank(self) -> Rank {
+        match self {
             Color::White => Rank::Fourth,
             Color::Black => Rank::Fifth,
         }
@@ -62,8 +62,8 @@ impl Color {
 
     /// Convert a `Color` to my seventh rank, which represents the rank before pawn promotion.
     #[inline]
-    pub const fn to_seventh_rank(&self) -> Rank {
-        match *self {
+    pub const fn to_seventh_rank(self) -> Rank {
+        match self {
             Color::White => Rank::Seventh,
             Color::Black => Rank::Second,
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,35 +1,41 @@
-use failure::Fail;
+use thiserror::Error;
 
 /// Sometimes, bad stuff happens.
-#[derive(Clone, Debug, Fail)]
-pub enum Error {
+#[derive(Clone, Debug, Error)]
+pub enum InvalidError {
     /// The FEN string is invalid
-    #[fail(display = "Invalid FEN string: {}", fen)]
-    InvalidFen { fen: String },
+    #[error("Invalid FEN string: {fen}")]
+    Fen { fen: String },
 
     /// The board created from BoardBuilder was found to be invalid
-    #[fail(
-        display = "The board specified did not pass sanity checks.  Are you sure the kings exist and the side to move cannot capture the opposing king?"
+    #[error(
+        "The board specified did not pass sanity checks.  Are you sure the kings exist and the side to move cannot capture the opposing king?"
     )]
-    InvalidBoard,
+    Board,
 
     /// An attempt was made to create a square from an invalid string
-    #[fail(display = "The string specified does not contain a valid algebraic notation square")]
-    InvalidSquare,
+    #[error("The string specified does not contain a valid algebraic notation square")]
+    Square,
 
     /// An attempt was made to create a move from an invalid SAN string
-    #[fail(display = "The string specified does not contain a valid SAN notation move")]
-    InvalidSanMove,
+    #[error("The string specified does not contain a valid SAN notation move")]
+    SanMove,
 
     /// An atempt was made to create a move from an invalid UCI string
-    #[fail(display = "The string specified does not contain a valid UCI notation move")]
-    InvalidUciMove,
+    #[error("The string specified does not contain a valid UCI notation move")]
+    UciMove,
 
     /// An attempt was made to convert a string not equal to "1"-"8" to a rank
-    #[fail(display = "The string specified does not contain a valid rank")]
-    InvalidRank,
+    #[error("The string specified does not contain a valid rank")]
+    Rank,
 
     /// An attempt was made to convert a string not equal to "a"-"h" to a file
-    #[fail(display = "The string specified does not contain a valid file")]
-    InvalidFile,
+    #[error("The string specified does not contain a valid file")]
+    File,
+}
+
+#[derive(Clone, Debug, Error)]
+pub enum Error {
+    #[error("invalid state")]
+    Invalid(#[from] InvalidError),
 }

--- a/src/file.rs
+++ b/src/file.rs
@@ -71,7 +71,7 @@ impl FromStr for File {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if s.len() < 1 {
+        if s.is_empty() {
             return Err(Error::InvalidFile);
         }
         match s.chars().next().unwrap() {

--- a/src/file.rs
+++ b/src/file.rs
@@ -33,7 +33,7 @@ pub const ALL_FILES: [File; NUM_FILES] = [
 impl File {
     /// Convert a `usize` into a `File` (the inverse of to_index).  If i > 7, wrap around.
     #[inline]
-    pub fn from_index(i: usize) -> File {
+    pub const fn from_index(i: usize) -> File {
         // match is optimized to no-op with opt-level=1 with rustc 1.53.0
         match i & 7 {
             0 => File::A,
@@ -50,19 +50,19 @@ impl File {
 
     /// Go one file to the left.  If impossible, wrap around.
     #[inline]
-    pub fn left(&self) -> File {
+    pub const fn left(&self) -> File {
         File::from_index(self.to_index().wrapping_sub(1))
     }
 
     /// Go one file to the right.  If impossible, wrap around.
     #[inline]
-    pub fn right(&self) -> File {
+    pub const fn right(&self) -> File {
         File::from_index(self.to_index() + 1)
     }
 
     /// Convert this `File` into a `usize` from 0 to 7 inclusive.
     #[inline]
-    pub fn to_index(&self) -> usize {
+    pub const fn to_index(&self) -> usize {
         *self as usize
     }
 }

--- a/src/file.rs
+++ b/src/file.rs
@@ -1,4 +1,4 @@
-use crate::error::Error;
+use crate::error::InvalidError;
 use std::str::FromStr;
 
 /// Describe a file (column) on a chess board
@@ -62,17 +62,17 @@ impl File {
 
     /// Convert this `File` into a `usize` from 0 to 7 inclusive.
     #[inline]
-    pub const fn to_index(&self) -> usize {
-        *self as usize
+    pub const fn to_index(self) -> usize {
+        self as usize
     }
 }
 
 impl FromStr for File {
-    type Err = Error;
+    type Err = InvalidError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         if s.is_empty() {
-            return Err(Error::InvalidFile);
+            return Err(InvalidError::File);
         }
         match s.chars().next().unwrap() {
             'a' => Ok(File::A),
@@ -83,7 +83,7 @@ impl FromStr for File {
             'f' => Ok(File::F),
             'g' => Ok(File::G),
             'h' => Ok(File::H),
-            _ => Err(Error::InvalidFile),
+            _ => Err(InvalidError::File),
         }
     }
 }

--- a/src/game.rs
+++ b/src/game.rs
@@ -105,7 +105,7 @@ impl Game {
             }
             BoardStatus::Stalemate => Some(GameResult::Stalemate),
             BoardStatus::Ongoing => {
-                if self.moves.len() == 0 {
+                if self.moves.is_empty() {
                     None
                 } else if self.moves[self.moves.len() - 1] == Action::AcceptDraw {
                     Some(GameResult::DrawAccepted)
@@ -254,7 +254,7 @@ impl Game {
             }
         }
 
-        return false;
+        false
     }
 
     /// Declare a draw by 3-fold repitition or 50-move rule.
@@ -361,7 +361,7 @@ impl Game {
             return false;
         }
         self.moves.push(Action::OfferDraw(color));
-        return true;
+        true
     }
 
     /// Accept a draw offer from my opponent.
@@ -383,20 +383,14 @@ impl Game {
         if self.result().is_some() {
             return false;
         }
-        if self.moves.len() > 0 {
-            if self.moves[self.moves.len() - 1] == Action::OfferDraw(Color::White)
-                || self.moves[self.moves.len() - 1] == Action::OfferDraw(Color::Black)
-            {
-                self.moves.push(Action::AcceptDraw);
-                return true;
-            }
+        if !self.moves.is_empty() && (self.moves[self.moves.len() - 1] == Action::OfferDraw(Color::White) || self.moves[self.moves.len() - 1] == Action::OfferDraw(Color::Black)) {
+            self.moves.push(Action::AcceptDraw);
+            return true;
         }
 
-        if self.moves.len() > 1 {
-            if self.moves[self.moves.len() - 2] == Action::OfferDraw(!self.side_to_move()) {
-                self.moves.push(Action::AcceptDraw);
-                return true;
-            }
+        if self.moves.len() > 1 && self.moves[self.moves.len() - 2] == Action::OfferDraw(!self.side_to_move()) {
+            self.moves.push(Action::AcceptDraw);
+            return true;
         }
 
         false
@@ -415,7 +409,7 @@ impl Game {
             return false;
         }
         self.moves.push(Action::Resign(color));
-        return true;
+        true
     }
 }
 
@@ -431,7 +425,7 @@ impl FromStr for Game {
 pub fn fake_pgn_parser(moves: &str) -> Game {
     moves
         .split_whitespace()
-        .filter(|s| !s.ends_with("."))
+        .filter(|s| !s.ends_with('.'))
         .fold(Game::new(), |mut g, m| {
             g.make_move(ChessMove::from_san(&g.current_position(), m).expect("Valid SAN Move"));
             g

--- a/src/gen_tables/between.rs
+++ b/src/gen_tables/between.rs
@@ -57,7 +57,6 @@ pub fn gen_between() {
     }
 }
 
-
 // Write the BETWEEN array to the specified file.
 #[allow(clippy::needless_range_loop)]
 pub fn write_between(f: &mut File) {

--- a/src/gen_tables/between.rs
+++ b/src/gen_tables/between.rs
@@ -59,14 +59,14 @@ pub fn gen_between() {
 
 // Write the BETWEEN array to the specified file.
 pub fn write_between(f: &mut File) {
-    write!(f, "const BETWEEN: [[BitBoard; 64]; 64] = [[\n").unwrap();
+    writeln!(f, "const BETWEEN: [[BitBoard; 64]; 64] = [[").unwrap();
     for i in 0..64 {
         for j in 0..64 {
-            unsafe { write!(f, "    BitBoard({}),\n", BETWEEN[i][j].0).unwrap() };
+            unsafe { writeln!(f, "    BitBoard({}),", BETWEEN[i][j].0).unwrap() };
         }
         if i != 63 {
-            write!(f, "  ], [\n").unwrap();
+            writeln!(f, "  ], [").unwrap();
         }
     }
-    write!(f, "]];\n").unwrap();
+    writeln!(f, "]];").unwrap();
 }

--- a/src/gen_tables/between.rs
+++ b/src/gen_tables/between.rs
@@ -57,7 +57,9 @@ pub fn gen_between() {
     }
 }
 
+
 // Write the BETWEEN array to the specified file.
+#[allow(clippy::needless_range_loop)]
 pub fn write_between(f: &mut File) {
     writeln!(f, "const BETWEEN: [[BitBoard; 64]; 64] = [[").unwrap();
     for i in 0..64 {

--- a/src/gen_tables/generate_all_tables.rs
+++ b/src/gen_tables/generate_all_tables.rs
@@ -4,7 +4,6 @@
 
 #![allow(dead_code)]
 
-
 use std::env;
 use std::fs::File;
 use std::path::Path;

--- a/src/gen_tables/generate_all_tables.rs
+++ b/src/gen_tables/generate_all_tables.rs
@@ -4,8 +4,6 @@
 
 #![allow(dead_code)]
 
-// it to be easily followed.
-extern crate rand;
 
 use std::env;
 use std::fs::File;

--- a/src/gen_tables/generate_all_tables.rs
+++ b/src/gen_tables/generate_all_tables.rs
@@ -38,7 +38,7 @@ pub fn generate_all_tables() {
 
     let out_dir = env::var("OUT_DIR").unwrap();
     let magic_path = Path::new(&out_dir).join("magic_gen.rs");
-    let mut f = File::create(&magic_path).unwrap();
+    let mut f = File::create(magic_path).unwrap();
 
     write_king_moves(&mut f);
     write_knight_moves(&mut f);
@@ -53,7 +53,7 @@ pub fn generate_all_tables() {
     write_bitboard_data(&mut f);
 
     let zobrist_path = Path::new(&out_dir).join("zobrist_gen.rs");
-    let mut z = File::create(&zobrist_path).unwrap();
+    let mut z = File::create(zobrist_path).unwrap();
 
     write_zobrist(&mut z);
 }

--- a/src/gen_tables/king.rs
+++ b/src/gen_tables/king.rs
@@ -79,8 +79,7 @@ pub fn write_king_moves(f: &mut File) {
         writeln!(
             f,
             " BitBoard({}), BitBoard({})];",
-            KINGSIDE_CASTLE_SQUARES[0].0,
-            KINGSIDE_CASTLE_SQUARES[1].0
+            KINGSIDE_CASTLE_SQUARES[0].0, KINGSIDE_CASTLE_SQUARES[1].0
         )
         .unwrap()
     };
@@ -90,8 +89,7 @@ pub fn write_king_moves(f: &mut File) {
         writeln!(
             f,
             " BitBoard({}), BitBoard({})];",
-            QUEENSIDE_CASTLE_SQUARES[0].0,
-            QUEENSIDE_CASTLE_SQUARES[1].0
+            QUEENSIDE_CASTLE_SQUARES[0].0, QUEENSIDE_CASTLE_SQUARES[1].0
         )
         .unwrap()
     };

--- a/src/gen_tables/king.rs
+++ b/src/gen_tables/king.rs
@@ -67,37 +67,37 @@ fn gen_castle_moves() -> BitBoard {
 
 // Write the KING_MOVES array to the specified file.
 pub fn write_king_moves(f: &mut File) {
-    write!(f, "const KING_MOVES: [BitBoard; 64] = [\n").unwrap();
+    writeln!(f, "const KING_MOVES: [BitBoard; 64] = [").unwrap();
     for i in 0..64 {
-        unsafe { write!(f, "    BitBoard({}),\n", KING_MOVES[i].0).unwrap() };
+        unsafe { writeln!(f, "    BitBoard({}),", KING_MOVES[i].0).unwrap() };
     }
-    write!(f, "];\n").unwrap();
+    writeln!(f, "];").unwrap();
 
-    write!(f, "pub const KINGSIDE_CASTLE_SQUARES: [BitBoard; 2] = [\n").unwrap();
+    writeln!(f, "pub const KINGSIDE_CASTLE_SQUARES: [BitBoard; 2] = [").unwrap();
     unsafe {
-        write!(
+        writeln!(
             f,
-            " BitBoard({}), BitBoard({})];\n",
+            " BitBoard({}), BitBoard({})];",
             KINGSIDE_CASTLE_SQUARES[0].0,
             KINGSIDE_CASTLE_SQUARES[1].0
         )
         .unwrap()
     };
 
-    write!(f, "pub const QUEENSIDE_CASTLE_SQUARES: [BitBoard; 2] = [\n").unwrap();
+    writeln!(f, "pub const QUEENSIDE_CASTLE_SQUARES: [BitBoard; 2] = [").unwrap();
     unsafe {
-        write!(
+        writeln!(
             f,
-            " BitBoard({}), BitBoard({})];\n",
+            " BitBoard({}), BitBoard({})];",
             QUEENSIDE_CASTLE_SQUARES[0].0,
             QUEENSIDE_CASTLE_SQUARES[1].0
         )
         .unwrap()
     };
 
-    write!(
+    writeln!(
         f,
-        "const CASTLE_MOVES: BitBoard = BitBoard({});\n",
+        "const CASTLE_MOVES: BitBoard = BitBoard({});",
         gen_castle_moves().0
     )
     .unwrap();

--- a/src/gen_tables/king.rs
+++ b/src/gen_tables/king.rs
@@ -66,6 +66,7 @@ fn gen_castle_moves() -> BitBoard {
 }
 
 // Write the KING_MOVES array to the specified file.
+#[allow(clippy::needless_range_loop)]
 pub fn write_king_moves(f: &mut File) {
     writeln!(f, "const KING_MOVES: [BitBoard; 64] = [").unwrap();
     for i in 0..64 {

--- a/src/gen_tables/knights.rs
+++ b/src/gen_tables/knights.rs
@@ -28,6 +28,7 @@ pub fn gen_knight_moves() {
 }
 
 // Write the KNIGHT_MOVES array to the specified file.
+#[allow(clippy::needless_range_loop)]
 pub fn write_knight_moves(f: &mut File) {
     writeln!(f, "const KNIGHT_MOVES: [BitBoard; 64] = [").unwrap();
     for i in 0..64 {

--- a/src/gen_tables/knights.rs
+++ b/src/gen_tables/knights.rs
@@ -29,9 +29,9 @@ pub fn gen_knight_moves() {
 
 // Write the KNIGHT_MOVES array to the specified file.
 pub fn write_knight_moves(f: &mut File) {
-    write!(f, "const KNIGHT_MOVES: [BitBoard; 64] = [\n").unwrap();
+    writeln!(f, "const KNIGHT_MOVES: [BitBoard; 64] = [").unwrap();
     for i in 0..64 {
-        unsafe { write!(f, "    BitBoard({}),\n", KNIGHT_MOVES[i].0).unwrap() };
+        unsafe { writeln!(f, "    BitBoard({}),", KNIGHT_MOVES[i].0).unwrap() };
     }
-    write!(f, "];\n").unwrap();
+    writeln!(f, "];").unwrap();
 }

--- a/src/gen_tables/lines.rs
+++ b/src/gen_tables/lines.rs
@@ -47,6 +47,7 @@ pub fn gen_lines() {
 }
 
 // Write the LINE array to the specified file.
+#[allow(clippy::needless_range_loop)]
 pub fn write_lines(f: &mut File) {
     writeln!(f, "const LINE: [[BitBoard; 64]; 64] = [[").unwrap();
     for i in 0..64 {

--- a/src/gen_tables/lines.rs
+++ b/src/gen_tables/lines.rs
@@ -48,14 +48,14 @@ pub fn gen_lines() {
 
 // Write the LINE array to the specified file.
 pub fn write_lines(f: &mut File) {
-    write!(f, "const LINE: [[BitBoard; 64]; 64] = [[\n").unwrap();
+    writeln!(f, "const LINE: [[BitBoard; 64]; 64] = [[").unwrap();
     for i in 0..64 {
         for j in 0..64 {
-            unsafe { write!(f, "    BitBoard({}),\n", LINE[i][j].0).unwrap() };
+            unsafe { writeln!(f, "    BitBoard({}),", LINE[i][j].0).unwrap() };
         }
         if i != 63 {
-            write!(f, "  ], [\n").unwrap();
+            writeln!(f, "  ], [").unwrap();
         }
     }
-    write!(f, "]];\n").unwrap();
+    writeln!(f, "]];").unwrap();
 }

--- a/src/gen_tables/magic.rs
+++ b/src/gen_tables/magic.rs
@@ -135,6 +135,7 @@ pub fn gen_all_magic() {
 }
 
 // Write the MAGIC_NUMBERS and MOVES arrays to the specified file.
+#[allow(clippy::needless_range_loop)]
 pub fn write_magic(f: &mut File) {
     writeln!(f, "#[derive(Copy, Clone)]").unwrap();
     writeln!(f, "struct Magic {{").unwrap();
@@ -162,7 +163,7 @@ pub fn write_magic(f: &mut File) {
     writeln!(f, "]];").unwrap();
 
     unsafe {
-        writeln!(f, "const MOVES: [BitBoard; {}] = [", GENERATED_NUM_MOVES).unwrap();
+        writeln!(f, "static MOVES: [BitBoard; {}] = [", GENERATED_NUM_MOVES).unwrap();
         for i in 0..GENERATED_NUM_MOVES {
             writeln!(f, "    BitBoard({}),", MOVES[i].0).unwrap();
         }

--- a/src/gen_tables/magic.rs
+++ b/src/gen_tables/magic.rs
@@ -75,7 +75,7 @@ fn generate_magic(sq: Square, piece: Piece, cur_offset: usize) -> usize {
 
     let mut new_magic = Magic {
         magic_number: EMPTY,
-        mask: mask,
+        mask,
         offset: new_offset as u32,
         rightshift: ((questions.len() as u64).leading_zeros() + 1) as u8,
     };
@@ -136,19 +136,19 @@ pub fn gen_all_magic() {
 
 // Write the MAGIC_NUMBERS and MOVES arrays to the specified file.
 pub fn write_magic(f: &mut File) {
-    write!(f, "#[derive(Copy, Clone)]\n").unwrap();
-    write!(f, "struct Magic {{\n").unwrap();
-    write!(f, "    magic_number: BitBoard,\n").unwrap();
-    write!(f, "    mask: BitBoard,\n").unwrap();
-    write!(f, "    offset: u32,\n").unwrap();
-    write!(f, "    rightshift: u8\n").unwrap();
+    writeln!(f, "#[derive(Copy, Clone)]").unwrap();
+    writeln!(f, "struct Magic {{").unwrap();
+    writeln!(f, "    magic_number: BitBoard,").unwrap();
+    writeln!(f, "    mask: BitBoard,").unwrap();
+    writeln!(f, "    offset: u32,").unwrap();
+    writeln!(f, "    rightshift: u8").unwrap();
     write!(f, "}}\n\n").unwrap();
 
-    write!(f, "const MAGIC_NUMBERS: [[Magic; 64]; 2] = [[\n").unwrap();
+    writeln!(f, "const MAGIC_NUMBERS: [[Magic; 64]; 2] = [[").unwrap();
     for i in 0..2 {
         for j in 0..64 {
             unsafe {
-                write!(f, "    Magic {{ magic_number: BitBoard({}), mask: BitBoard({}), offset: {}, rightshift: {} }},\n",
+                writeln!(f, "    Magic {{ magic_number: BitBoard({}), mask: BitBoard({}), offset: {}, rightshift: {} }},",
                     MAGIC_NUMBERS[i][j].magic_number.0,
                     MAGIC_NUMBERS[i][j].mask.0,
                     MAGIC_NUMBERS[i][j].offset,
@@ -156,16 +156,16 @@ pub fn write_magic(f: &mut File) {
             }
         }
         if i != 1 {
-            write!(f, "], [\n").unwrap();
+            writeln!(f, "], [").unwrap();
         }
     }
-    write!(f, "]];\n").unwrap();
+    writeln!(f, "]];").unwrap();
 
     unsafe {
-        write!(f, "const MOVES: [BitBoard; {}] = [\n", GENERATED_NUM_MOVES).unwrap();
+        writeln!(f, "const MOVES: [BitBoard; {}] = [", GENERATED_NUM_MOVES).unwrap();
         for i in 0..GENERATED_NUM_MOVES {
-            write!(f, "    BitBoard({}),\n", MOVES[i].0).unwrap();
+            writeln!(f, "    BitBoard({}),", MOVES[i].0).unwrap();
         }
     }
-    write!(f, "];\n").unwrap();
+    writeln!(f, "];").unwrap();
 }

--- a/src/gen_tables/magic_helpers.rs
+++ b/src/gen_tables/magic_helpers.rs
@@ -35,16 +35,16 @@ fn rook_directions() -> Vec<fn(Square) -> Option<Square>> {
 // Return a list of directions for the bishop.
 fn bishop_directions() -> Vec<fn(Square) -> Option<Square>> {
     fn nw(sq: Square) -> Option<Square> {
-        sq.left().map_or(None, |s| s.up())
+        sq.left().and_then(|s| s.up())
     }
     fn ne(sq: Square) -> Option<Square> {
-        sq.right().map_or(None, |s| s.up())
+        sq.right().and_then(|s| s.up())
     }
     fn sw(sq: Square) -> Option<Square> {
-        sq.left().map_or(None, |s| s.down())
+        sq.left().and_then(|s| s.down())
     }
     fn se(sq: Square) -> Option<Square> {
-        sq.right().map_or(None, |s| s.down())
+        sq.right().and_then(|s| s.down())
     }
 
     vec![nw, ne, sw, se]
@@ -110,7 +110,7 @@ pub fn questions_and_answers(sq: Square, piece: Piece) -> (Vec<BitBoard>, Vec<Bi
         let mut answer = EMPTY;
         for m in movement.iter() {
             let mut next = m(sq);
-            while next != None {
+            while next.is_some() {
                 answer ^= BitBoard::from_square(next.unwrap());
                 if (BitBoard::from_square(next.unwrap()) & *question) != EMPTY {
                     break;

--- a/src/gen_tables/mod.rs
+++ b/src/gen_tables/mod.rs
@@ -4,9 +4,6 @@
 
 #![allow(dead_code)]
 
-// it to be easily followed.
-extern crate rand;
-
 mod between;
 #[cfg(target_feature = "bmi2")]
 mod bmis;

--- a/src/gen_tables/pawns.rs
+++ b/src/gen_tables/pawns.rs
@@ -87,41 +87,41 @@ pub fn gen_dest_double_moves() -> BitBoard {
 
 // Write the PAWN_MOVES array to the specified file.
 pub fn write_pawn_moves(f: &mut File) {
-    write!(f, "const PAWN_MOVES: [[BitBoard; 64]; 2] = [[\n").unwrap();
+    writeln!(f, "const PAWN_MOVES: [[BitBoard; 64]; 2] = [[").unwrap();
     for i in 0..2 {
         for j in 0..64 {
-            unsafe { write!(f, "    BitBoard({}),\n", PAWN_MOVES[i][j].0).unwrap() };
+            unsafe { writeln!(f, "    BitBoard({}),", PAWN_MOVES[i][j].0).unwrap() };
         }
         if i != 1 {
-            write!(f, "  ], [\n").unwrap();
+            writeln!(f, "  ], [").unwrap();
         }
     }
-    write!(f, "]];\n").unwrap();
+    writeln!(f, "]];").unwrap();
 }
 
 // Write the PAWN_ATTACKS array to the specified file.
 pub fn write_pawn_attacks(f: &mut File) {
-    write!(f, "const PAWN_ATTACKS: [[BitBoard; 64]; 2] = [[\n").unwrap();
+    writeln!(f, "const PAWN_ATTACKS: [[BitBoard; 64]; 2] = [[").unwrap();
     for i in 0..2 {
         for j in 0..64 {
-            unsafe { write!(f, "    BitBoard({}),\n", PAWN_ATTACKS[i][j].0).unwrap() };
+            unsafe { writeln!(f, "    BitBoard({}),", PAWN_ATTACKS[i][j].0).unwrap() };
         }
         if i != 1 {
-            write!(f, "  ], [\n").unwrap();
+            writeln!(f, "  ], [").unwrap();
         }
     }
-    write!(f, "]];\n").unwrap();
+    writeln!(f, "]];").unwrap();
 
-    write!(
+    writeln!(
         f,
-        "const PAWN_SOURCE_DOUBLE_MOVES: BitBoard = BitBoard({0});\n",
+        "const PAWN_SOURCE_DOUBLE_MOVES: BitBoard = BitBoard({0});",
         gen_source_double_moves().0
     )
     .unwrap();
 
-    write!(
+    writeln!(
         f,
-        "const PAWN_DEST_DOUBLE_MOVES: BitBoard = BitBoard({0});\n",
+        "const PAWN_DEST_DOUBLE_MOVES: BitBoard = BitBoard({0});",
         gen_dest_double_moves().0
     )
     .unwrap();

--- a/src/gen_tables/pawns.rs
+++ b/src/gen_tables/pawns.rs
@@ -86,6 +86,7 @@ pub fn gen_dest_double_moves() -> BitBoard {
 }
 
 // Write the PAWN_MOVES array to the specified file.
+#[allow(clippy::needless_range_loop)]
 pub fn write_pawn_moves(f: &mut File) {
     writeln!(f, "const PAWN_MOVES: [[BitBoard; 64]; 2] = [[").unwrap();
     for i in 0..2 {
@@ -100,6 +101,7 @@ pub fn write_pawn_moves(f: &mut File) {
 }
 
 // Write the PAWN_ATTACKS array to the specified file.
+#[allow(clippy::needless_range_loop)]
 pub fn write_pawn_attacks(f: &mut File) {
     writeln!(f, "const PAWN_ATTACKS: [[BitBoard; 64]; 2] = [[").unwrap();
     for i in 0..2 {

--- a/src/gen_tables/ranks_files.rs
+++ b/src/gen_tables/ranks_files.rs
@@ -55,6 +55,7 @@ pub fn gen_bitboard_data() {
 }
 
 // Write the FILES array to the specified file.
+#[allow(clippy::needless_range_loop)]
 pub fn write_bitboard_data(f: &mut File) {
     unsafe {
         writeln!(f, "const FILES: [BitBoard; 8] = [").unwrap();

--- a/src/gen_tables/ranks_files.rs
+++ b/src/gen_tables/ranks_files.rs
@@ -57,25 +57,25 @@ pub fn gen_bitboard_data() {
 // Write the FILES array to the specified file.
 pub fn write_bitboard_data(f: &mut File) {
     unsafe {
-        write!(f, "const FILES: [BitBoard; 8] = [\n").unwrap();
+        writeln!(f, "const FILES: [BitBoard; 8] = [").unwrap();
         for i in 0..8 {
-            write!(f, "    BitBoard({}),\n", FILES[i].0).unwrap();
+            writeln!(f, "    BitBoard({}),", FILES[i].0).unwrap();
         }
-        write!(f, "];\n").unwrap();
-        write!(f, "const ADJACENT_FILES: [BitBoard; 8] = [\n").unwrap();
+        writeln!(f, "];").unwrap();
+        writeln!(f, "const ADJACENT_FILES: [BitBoard; 8] = [").unwrap();
         for i in 0..8 {
-            write!(f, "    BitBoard({}),\n", ADJACENT_FILES[i].0).unwrap();
+            writeln!(f, "    BitBoard({}),", ADJACENT_FILES[i].0).unwrap();
         }
-        write!(f, "];\n").unwrap();
-        write!(f, "const RANKS: [BitBoard; 8] = [\n").unwrap();
+        writeln!(f, "];").unwrap();
+        writeln!(f, "const RANKS: [BitBoard; 8] = [").unwrap();
         for i in 0..8 {
-            write!(f, "    BitBoard({}),\n", RANKS[i].0).unwrap();
+            writeln!(f, "    BitBoard({}),", RANKS[i].0).unwrap();
         }
-        write!(f, "];\n").unwrap();
-        write!(f, "/// What are all the edge squares on the `BitBoard`?\n").unwrap();
-        write!(
+        writeln!(f, "];").unwrap();
+        writeln!(f, "/// What are all the edge squares on the `BitBoard`?").unwrap();
+        writeln!(
             f,
-            "pub const EDGES: BitBoard = BitBoard({});\n",
+            "pub const EDGES: BitBoard = BitBoard({});",
             EDGES.0
         )
         .unwrap();

--- a/src/gen_tables/ranks_files.rs
+++ b/src/gen_tables/ranks_files.rs
@@ -74,11 +74,6 @@ pub fn write_bitboard_data(f: &mut File) {
         }
         writeln!(f, "];").unwrap();
         writeln!(f, "/// What are all the edge squares on the `BitBoard`?").unwrap();
-        writeln!(
-            f,
-            "pub const EDGES: BitBoard = BitBoard({});",
-            EDGES.0
-        )
-        .unwrap();
+        writeln!(f, "pub const EDGES: BitBoard = BitBoard({});", EDGES.0).unwrap();
     }
 }

--- a/src/gen_tables/rays.rs
+++ b/src/gen_tables/rays.rs
@@ -52,6 +52,7 @@ pub fn get_rays(sq: Square, piece: Piece) -> BitBoard {
 }
 
 // Write the RAYS array to the specified file.
+#[allow(clippy::needless_range_loop)]
 pub fn write_rays(f: &mut File) {
     writeln!(f, "const ROOK: usize = {};", 0).unwrap();
     writeln!(f, "const BISHOP: usize = {};", 1).unwrap();

--- a/src/gen_tables/rays.rs
+++ b/src/gen_tables/rays.rs
@@ -53,16 +53,16 @@ pub fn get_rays(sq: Square, piece: Piece) -> BitBoard {
 
 // Write the RAYS array to the specified file.
 pub fn write_rays(f: &mut File) {
-    write!(f, "const ROOK: usize = {};\n", 0).unwrap();
-    write!(f, "const BISHOP: usize = {};\n", 1).unwrap();
-    write!(f, "const RAYS: [[BitBoard; 64]; 2] = [[\n").unwrap();
+    writeln!(f, "const ROOK: usize = {};", 0).unwrap();
+    writeln!(f, "const BISHOP: usize = {};", 1).unwrap();
+    writeln!(f, "const RAYS: [[BitBoard; 64]; 2] = [[").unwrap();
     for i in 0..2 {
         for j in 0..64 {
-            unsafe { write!(f, "    BitBoard({}),\n", RAYS[i][j].0).unwrap() };
+            unsafe { writeln!(f, "    BitBoard({}),", RAYS[i][j].0).unwrap() };
         }
         if i != 1 {
-            write!(f, "  ], [\n").unwrap();
+            writeln!(f, "  ], [").unwrap();
         }
     }
-    write!(f, "]];\n").unwrap();
+    writeln!(f, "]];").unwrap();
 }

--- a/src/gen_tables/zobrist.rs
+++ b/src/gen_tables/zobrist.rs
@@ -15,44 +15,44 @@ pub fn write_zobrist(f: &mut File) {
 
     write!(f, "const SIDE_TO_MOVE: u64 = {};\n\n", rng.next_u64()).unwrap();
 
-    write!(
+    writeln!(
         f,
-        "const ZOBRIST_PIECES: [[[u64; NUM_SQUARES]; NUM_PIECES]; NUM_COLORS] = [[[\n"
+        "const ZOBRIST_PIECES: [[[u64; NUM_SQUARES]; NUM_PIECES]; NUM_COLORS] = [[["
     )
     .unwrap();
     for i in 0..NUM_COLORS {
         for j in 0..NUM_PIECES {
             for _ in 0..NUM_SQUARES {
-                write!(f, "    {},\n", rng.next_u64()).unwrap();
+                writeln!(f, "    {},", rng.next_u64()).unwrap();
             }
             if j != NUM_PIECES - 1 {
-                write!(f, "   ], [\n").unwrap();
+                writeln!(f, "   ], [").unwrap();
             }
         }
         if i != NUM_COLORS - 1 {
-            write!(f, "  ]], [[\n").unwrap();
+            writeln!(f, "  ]], [[").unwrap();
         }
     }
     write!(f, "]]];\n\n").unwrap();
 
-    write!(f, "const ZOBRIST_CASTLES: [[u64; 4]; NUM_COLORS] = [[\n").unwrap();
+    writeln!(f, "const ZOBRIST_CASTLES: [[u64; 4]; NUM_COLORS] = [[").unwrap();
     for i in 0..NUM_COLORS {
         for _ in 0..4 {
-            write!(f, "    {},\n", rng.next_u64()).unwrap();
+            writeln!(f, "    {},", rng.next_u64()).unwrap();
         }
         if i != NUM_COLORS - 1 {
-            write!(f, "  ], [\n").unwrap();
+            writeln!(f, "  ], [").unwrap();
         }
     }
     write!(f, "]];\n\n").unwrap();
 
-    write!(f, "const ZOBRIST_EP: [[u64; NUM_FILES]; NUM_COLORS] = [[\n").unwrap();
+    writeln!(f, "const ZOBRIST_EP: [[u64; NUM_FILES]; NUM_COLORS] = [[").unwrap();
     for i in 0..NUM_COLORS {
         for _ in 0..NUM_FILES {
-            write!(f, "    {},\n", rng.next_u64()).unwrap();
+            writeln!(f, "    {},", rng.next_u64()).unwrap();
         }
         if i != NUM_COLORS - 1 {
-            write!(f, "], [\n").unwrap();
+            writeln!(f, "], [").unwrap();
         }
     }
     write!(f, "]];\n\n").unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,4 +73,4 @@ mod board_builder;
 pub use crate::board_builder::BoardBuilder;
 
 mod error;
-pub use crate::error::Error;
+pub use crate::error::{Error, InvalidError};

--- a/src/movegen/movegen.rs
+++ b/src/movegen/movegen.rs
@@ -22,7 +22,7 @@ impl SquareAndBitBoard {
         SquareAndBitBoard {
             square: sq,
             bitboard: bb,
-            promotion: promotion,
+            promotion,
         }
     }
 }
@@ -98,21 +98,21 @@ impl MoveGen {
         let mut movelist = NoDrop::new(ArrayVec::<SquareAndBitBoard, 18>::new());
 
         if checkers == EMPTY {
-            PawnType::legals::<NotInCheckType>(&mut movelist, &board, mask);
-            KnightType::legals::<NotInCheckType>(&mut movelist, &board, mask);
-            BishopType::legals::<NotInCheckType>(&mut movelist, &board, mask);
-            RookType::legals::<NotInCheckType>(&mut movelist, &board, mask);
-            QueenType::legals::<NotInCheckType>(&mut movelist, &board, mask);
-            KingType::legals::<NotInCheckType>(&mut movelist, &board, mask);
+            PawnType::legals::<NotInCheckType>(&mut movelist, board, mask);
+            KnightType::legals::<NotInCheckType>(&mut movelist, board, mask);
+            BishopType::legals::<NotInCheckType>(&mut movelist, board, mask);
+            RookType::legals::<NotInCheckType>(&mut movelist, board, mask);
+            QueenType::legals::<NotInCheckType>(&mut movelist, board, mask);
+            KingType::legals::<NotInCheckType>(&mut movelist, board, mask);
         } else if checkers.popcnt() == 1 {
-            PawnType::legals::<InCheckType>(&mut movelist, &board, mask);
-            KnightType::legals::<InCheckType>(&mut movelist, &board, mask);
-            BishopType::legals::<InCheckType>(&mut movelist, &board, mask);
-            RookType::legals::<InCheckType>(&mut movelist, &board, mask);
-            QueenType::legals::<InCheckType>(&mut movelist, &board, mask);
-            KingType::legals::<InCheckType>(&mut movelist, &board, mask);
+            PawnType::legals::<InCheckType>(&mut movelist, board, mask);
+            KnightType::legals::<InCheckType>(&mut movelist, board, mask);
+            BishopType::legals::<InCheckType>(&mut movelist, board, mask);
+            RookType::legals::<InCheckType>(&mut movelist, board, mask);
+            QueenType::legals::<InCheckType>(&mut movelist, board, mask);
+            KingType::legals::<InCheckType>(&mut movelist, board, mask);
         } else {
-            KingType::legals::<InCheckType>(&mut movelist, &board, mask);
+            KingType::legals::<InCheckType>(&mut movelist, board, mask);
         }
 
         movelist

--- a/src/movegen/movegen.rs
+++ b/src/movegen/movegen.rs
@@ -9,7 +9,6 @@ use arrayvec::ArrayVec;
 use nodrop::NoDrop;
 use std::iter::ExactSizeIterator;
 
-
 #[derive(Copy, Clone, PartialEq, PartialOrd)]
 pub struct SquareAndBitBoard {
     square: Square,

--- a/src/movegen/movegen.rs
+++ b/src/movegen/movegen.rs
@@ -8,7 +8,7 @@ use crate::square::Square;
 use arrayvec::ArrayVec;
 use nodrop::NoDrop;
 use std::iter::ExactSizeIterator;
-use std::mem;
+
 
 #[derive(Copy, Clone, PartialEq, PartialOrd)]
 pub struct SquareAndBitBoard {
@@ -250,7 +250,7 @@ impl MoveGen {
         } else {
             iterable.set_iterator_mask(*targets);
             for x in &mut iterable {
-                let mut bresult = mem::MaybeUninit::<Board>::uninit();
+                let mut bresult = core::mem::MaybeUninit::<Board>::uninit();
                 unsafe {
                     board.make_move(x, &mut *bresult.as_mut_ptr());
                     result += MoveGen::movegen_perft_test(&*bresult.as_ptr(), depth - 1);
@@ -258,7 +258,7 @@ impl MoveGen {
             }
             iterable.set_iterator_mask(!EMPTY);
             for x in &mut iterable {
-                let mut bresult = mem::MaybeUninit::<Board>::uninit();
+                let mut bresult = core::mem::MaybeUninit::<Board>::uninit();
                 unsafe {
                     board.make_move(x, &mut *bresult.as_mut_ptr());
                     result += MoveGen::movegen_perft_test(&*bresult.as_ptr(), depth - 1);

--- a/src/movegen/piece_type.rs
+++ b/src/movegen/piece_type.rs
@@ -93,14 +93,17 @@ impl PawnType {
         let rooks = (board.pieces(Piece::Rook) | board.pieces(Piece::Queen))
             & board.color_combined(!board.side_to_move());
 
-        if (get_rook_rays(ksq) & rooks) != EMPTY && (get_rook_moves(ksq, combined) & rooks) != EMPTY {
+        if (get_rook_rays(ksq) & rooks) != EMPTY && (get_rook_moves(ksq, combined) & rooks) != EMPTY
+        {
             return false;
         }
 
         let bishops = (board.pieces(Piece::Bishop) | board.pieces(Piece::Queen))
             & board.color_combined(!board.side_to_move());
 
-        if (get_bishop_rays(ksq) & bishops) != EMPTY && (get_bishop_moves(ksq, combined) & bishops) != EMPTY {
+        if (get_bishop_rays(ksq) & bishops) != EMPTY
+            && (get_bishop_moves(ksq, combined) & bishops) != EMPTY
+        {
             return false;
         }
 

--- a/src/movegen/piece_type.rs
+++ b/src/movegen/piece_type.rs
@@ -14,7 +14,6 @@ use crate::magic::{
 pub trait PieceType {
     fn is(piece: Piece) -> bool;
     fn into_piece() -> Piece;
-    #[inline(always)]
     fn pseudo_legals(src: Square, color: Color, combined: BitBoard, mask: BitBoard) -> BitBoard;
     #[inline(always)]
     fn legals<T>(movelist: &mut MoveList, board: &Board, mask: BitBoard)

--- a/src/movegen/piece_type.rs
+++ b/src/movegen/piece_type.rs
@@ -93,22 +93,18 @@ impl PawnType {
         let rooks = (board.pieces(Piece::Rook) | board.pieces(Piece::Queen))
             & board.color_combined(!board.side_to_move());
 
-        if (get_rook_rays(ksq) & rooks) != EMPTY {
-            if (get_rook_moves(ksq, combined) & rooks) != EMPTY {
-                return false;
-            }
+        if (get_rook_rays(ksq) & rooks) != EMPTY && (get_rook_moves(ksq, combined) & rooks) != EMPTY {
+            return false;
         }
 
         let bishops = (board.pieces(Piece::Bishop) | board.pieces(Piece::Queen))
             & board.color_combined(!board.side_to_move());
 
-        if (get_bishop_rays(ksq) & bishops) != EMPTY {
-            if (get_bishop_moves(ksq, combined) & bishops) != EMPTY {
-                return false;
-            }
+        if (get_bishop_rays(ksq) & bishops) != EMPTY && (get_bishop_moves(ksq, combined) & bishops) != EMPTY {
+            return false;
         }
 
-        return true;
+        true
     }
 }
 
@@ -325,7 +321,7 @@ impl KingType {
             board.pieces(Piece::Pawn) & board.color_combined(!board.side_to_move()),
         );
 
-        return attackers == EMPTY;
+        attackers == EMPTY
     }
 }
 

--- a/src/piece.rs
+++ b/src/piece.rs
@@ -2,6 +2,7 @@ use crate::color::Color;
 use std::fmt;
 
 /// Represent a chess piece as a very simple enum
+#[repr(u8)]
 #[derive(PartialEq, Eq, Ord, PartialOrd, Copy, Clone, Debug, Hash)]
 pub enum Piece {
     Pawn,

--- a/src/piece.rs
+++ b/src/piece.rs
@@ -35,8 +35,8 @@ pub const PROMOTION_PIECES: [Piece; 4] = [Piece::Queen, Piece::Knight, Piece::Ro
 impl Piece {
     /// Convert the `Piece` to a `usize` for table lookups.
     #[inline]
-    pub fn to_index(&self) -> usize {
-        *self as usize
+    pub fn to_index(self) -> usize {
+        self as usize
     }
 
     /// Convert a piece with a color to a string.  White pieces are uppercase, black pieces are
@@ -49,7 +49,7 @@ impl Piece {
     /// assert_eq!(Piece::Knight.to_string(Color::Black), "n");
     /// ```
     #[inline]
-    pub fn to_string(&self, color: Color) -> String {
+    pub fn to_string(self, color: Color) -> String {
         let piece = format!("{}", self);
         if color == Color::White {
             piece.to_uppercase()

--- a/src/rank.rs
+++ b/src/rank.rs
@@ -34,7 +34,7 @@ impl Rank {
     /// Convert a `usize` into a `Rank` (the inverse of to_index).  If the number is > 7, wrap
     /// around.
     #[inline]
-    pub fn from_index(i: usize) -> Rank {
+    pub const fn from_index(i: usize) -> Rank {
         // match is optimized to no-op with opt-level=1 with rustc 1.53.0
         match i & 7 {
             0 => Rank::First,
@@ -51,19 +51,19 @@ impl Rank {
 
     /// Go one rank down.  If impossible, wrap around.
     #[inline]
-    pub fn down(&self) -> Rank {
+    pub const fn down(&self) -> Rank {
         Rank::from_index(self.to_index().wrapping_sub(1))
     }
 
     /// Go one file up.  If impossible, wrap around.
     #[inline]
-    pub fn up(&self) -> Rank {
+    pub const fn up(&self) -> Rank {
         Rank::from_index(self.to_index() + 1)
     }
 
     /// Convert this `Rank` into a `usize` between 0 and 7 (inclusive).
     #[inline]
-    pub fn to_index(&self) -> usize {
+    pub const fn to_index(&self) -> usize {
         *self as usize
     }
 }

--- a/src/rank.rs
+++ b/src/rank.rs
@@ -72,7 +72,7 @@ impl FromStr for Rank {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if s.len() < 1 {
+        if s.is_empty() {
             return Err(Error::InvalidRank);
         }
         match s.chars().next().unwrap() {

--- a/src/rank.rs
+++ b/src/rank.rs
@@ -1,4 +1,4 @@
-use crate::error::Error;
+use crate::error::InvalidError;
 use std::str::FromStr;
 
 /// Describe a rank (row) on a chess board
@@ -63,17 +63,17 @@ impl Rank {
 
     /// Convert this `Rank` into a `usize` between 0 and 7 (inclusive).
     #[inline]
-    pub const fn to_index(&self) -> usize {
-        *self as usize
+    pub const fn to_index(self) -> usize {
+        self as usize
     }
 }
 
 impl FromStr for Rank {
-    type Err = Error;
+    type Err = InvalidError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         if s.is_empty() {
-            return Err(Error::InvalidRank);
+            return Err(InvalidError::Rank);
         }
         match s.chars().next().unwrap() {
             '1' => Ok(Rank::First),
@@ -84,7 +84,7 @@ impl FromStr for Rank {
             '6' => Ok(Rank::Sixth),
             '7' => Ok(Rank::Seventh),
             '8' => Ok(Rank::Eighth),
-            _ => Err(Error::InvalidRank),
+            _ => Err(InvalidError::Rank),
         }
     }
 }

--- a/src/square.rs
+++ b/src/square.rs
@@ -364,7 +364,7 @@ impl Square {
     /// assert_eq!(Square::make_square(Rank::Eighth, File::H).to_index(), 63);
     /// ```
     #[inline]
-    pub fn to_index(&self) -> usize {
+    pub const fn to_index(&self) -> usize {
         self.0 as usize
     }
 

--- a/src/square.rs
+++ b/src/square.rs
@@ -1,5 +1,5 @@
 use crate::color::Color;
-use crate::error::Error;
+use crate::error::InvalidError;
 use crate::file::File;
 use crate::rank::Rank;
 use std::fmt;
@@ -349,7 +349,7 @@ impl Square {
     /// assert_eq!(Square::make_square(Rank::Eighth, File::H).to_int(), 63);
     /// ```
     #[inline]
-    pub const fn to_int(&self) -> u8 {
+    pub const fn to_int(self) -> u8 {
         self.0
     }
 
@@ -364,7 +364,7 @@ impl Square {
     /// assert_eq!(Square::make_square(Rank::Eighth, File::H).to_index(), 63);
     /// ```
     #[inline]
-    pub const fn to_index(&self) -> usize {
+    pub const fn to_index(self) -> usize {
         self.0 as usize
     }
 
@@ -974,23 +974,23 @@ impl fmt::Display for Square {
 }
 
 impl FromStr for Square {
-    type Err = Error;
+    type Err = InvalidError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         if s.len() < 2 {
-            return Err(Error::InvalidSquare);
+            return Err(InvalidError::Square);
         }
         let ch: Vec<char> = s.chars().collect();
         match ch[0] {
             'a' | 'b' | 'c' | 'd' | 'e' | 'f' | 'g' | 'h' => {}
             _ => {
-                return Err(Error::InvalidSquare);
+                return Err(InvalidError::Square);
             }
         }
         match ch[1] {
             '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' => {}
             _ => {
-                return Err(Error::InvalidSquare);
+                return Err(InvalidError::Square);
             }
         }
         Ok(Square::make_square(

--- a/src/square.rs
+++ b/src/square.rs
@@ -967,8 +967,8 @@ impl fmt::Display for Square {
         write!(
             f,
             "{}{}",
-            (('a' as u8) + ((self.0 & 7) as u8)) as char,
-            (('1' as u8) + ((self.0 >> 3) as u8)) as char
+            (b'a' + (self.0 & 7)) as char,
+            (b'1' + (self.0 >> 3)) as char
         )
     }
 }

--- a/src/square.rs
+++ b/src/square.rs
@@ -42,7 +42,7 @@ impl Square {
     /// assert_eq!(Square::default(), bad_sq);
     /// ```
     #[inline]
-    pub fn new(sq: u8) -> Square {
+    pub const fn new(sq: u8) -> Square {
         Square(sq & 63)
     }
 
@@ -64,7 +64,7 @@ impl Square {
     /// }
     /// ```
     #[inline]
-    pub fn make_square(rank: Rank, file: File) -> Square {
+    pub const fn make_square(rank: Rank, file: File) -> Square {
         Square((rank.to_index() as u8) << 3 ^ (file.to_index() as u8))
     }
 
@@ -78,7 +78,7 @@ impl Square {
     /// assert_eq!(sq.get_rank(), Rank::Seventh);
     /// ```
     #[inline]
-    pub fn get_rank(&self) -> Rank {
+    pub const fn get_rank(&self) -> Rank {
         Rank::from_index((self.0 >> 3) as usize)
     }
 
@@ -349,7 +349,7 @@ impl Square {
     /// assert_eq!(Square::make_square(Rank::Eighth, File::H).to_int(), 63);
     /// ```
     #[inline]
-    pub fn to_int(&self) -> u8 {
+    pub const fn to_int(&self) -> u8 {
         self.0
     }
 


### PR DESCRIPTION
This Pull Request brings the library into the standards and convention of Rust at the time of writing, at least from my point of view.

- Everything that can be easily const is now const
- Migration from unmaintained crate `failure` to `thiserror`
- Migration from Rust Edition 2018 to 2021
  - Removal of the deprecated `extern crate foo;` syntax
  - Setting minimum Rust version to 1.56.0
  - Automatic migration by cargo fix
- Implementation of latest suggestions (automatic and manual) by clippy. This introduces breaking changes, that's the reason for the major version bump.
- Formatting
- Encoded starting position using `const`.

I really like this innovative, unconventional use of build.rs, however it also greatly increases build time. It might be possible to replace the build.rs file entirely by clever use of const. It might be even easier, once more operations are available to const. 

However the usage of static mut seems unnecessary, but I don't have the time to implement those changes.

On a additional note I think it's sufficient to rely on docs.rs.