### PR TITLE
Add checked BitBoard::to_maybe_square(); document to_square() on empty (#91)

### DIFF
--- a/src/bitboard.rs
+++ b/src/bitboard.rs
@@ -294,10 +294,42 @@ impl BitBoard {
         sq.map(|s| BitBoard::from_square(s))
     }
 
-    /// Convert a `BitBoard` to a `Square`.  This grabs the least-significant `Square`
+    /// Convert a `BitBoard` to a `Square`.  This grabs the least-significant `Square`.
+    ///
+    /// The `BitBoard` is assumed to be non-empty.  On an empty `BitBoard` this
+    /// returns [`Square::A1`], which is indistinguishable from a `BitBoard` with
+    /// only A1 set; use [`BitBoard::to_maybe_square`] (or iterate the `BitBoard`)
+    /// when it may be empty.
+    ///
+    /// ```
+    /// use chess::{BitBoard, Square};
+    ///
+    /// assert_eq!(BitBoard::from_square(Square::H8).to_square(), Square::H8);
+    /// ```
     #[inline]
     pub fn to_square(&self) -> Square {
         Square::new(self.0.trailing_zeros() as u8)
+    }
+
+    /// Convert a `BitBoard` to an `Option<Square>`, grabbing the least-significant
+    /// `Square`.  Returns `None` if the `BitBoard` is empty.
+    ///
+    /// This is the checked counterpart of [`BitBoard::to_square`], mirroring
+    /// [`BitBoard::from_maybe_square`].
+    ///
+    /// ```
+    /// use chess::{BitBoard, Square, EMPTY};
+    ///
+    /// assert_eq!(EMPTY.to_maybe_square(), None);
+    /// assert_eq!(BitBoard::from_square(Square::A1).to_maybe_square(), Some(Square::A1));
+    /// ```
+    #[inline]
+    pub fn to_maybe_square(&self) -> Option<Square> {
+        if self.0 == 0 {
+            None
+        } else {
+            Some(Square::new(self.0.trailing_zeros() as u8))
+        }
     }
 
     /// Count the number of `Squares` set in this `BitBoard`

--- a/src/bitboard.rs
+++ b/src/bitboard.rs
@@ -328,7 +328,7 @@ impl BitBoard {
         if self.0 == 0 {
             None
         } else {
-            Some(Square::new(self.0.trailing_zeros() as u8))
+            Some(self.to_square())
         }
     }
 


### PR DESCRIPTION
Addresses #91.

On current `main`, `BitBoard::new(0).to_square()` returns `A1`, not the invalid `a9` from the report — `Square::new` already masks with `& 63`, so the out-of-range square is gone. What remains is that `to_square()` silently returns `A1` for an empty `BitBoard`, which is indistinguishable from a `BitBoard` with only A1 set.

This adds `BitBoard::to_maybe_square() -> Option<Square>`, the checked counterpart of `to_square()` (mirroring the existing `from_maybe_square`), returning `None` when the `BitBoard` is empty. `to_square()`'s documentation now states its non-empty precondition and points to the checked method.

Additive and non-breaking. Doctests on both methods serve as tests; the full suite (36 unit + 142 doc) passes. `to_maybe_square` takes `&self` to match the existing `to_square`/`to_size` convention.
